### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To try Planck.js, simply add `planck-with-testbed.js` script to your HTML code a
 
 ```html
 <html><body>
-  <script src="https://cdn.jsdelivr.net/planck/0.1/planck-with-testbed.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/planck-js@0.1/dist/planck-with-testbed.js"></script>
   <script>
     planck.testbed(function(testbed) {
       var world = planck.World();

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   },
   "main": "lib/index.js",
   "files": [
+    "dist/",
     "doc/",
     "lib/",
     "test/",
-    "testbed/"
+    "testbed/"   
   ],
   "author": "Ali Shakiba",
   "contributors": [{


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link, but it will work only after you release a new version, because dist files were excluded in the old versions.

You can find links for all files at https://www.jsdelivr.com/package/npm/planck-js.

Feel free to ping me if you have any questions regarding this change.