### PR TITLE
Add Mat22 and Mat33 to exports and typescript definitions

### DIFF
--- a/lib/common/Mat33.js
+++ b/lib/common/Mat33.js
@@ -37,7 +37,7 @@ function Mat33(a, b, c) {
     this.ez = Vec3.clone(c);
   } else {
     this.ex = Vec3();
-    this.ey = Vec3()
+    this.ey = Vec3();
     this.ez = Vec3();
   }
 };

--- a/lib/common/Vec3.js
+++ b/lib/common/Vec3.js
@@ -39,6 +39,19 @@ function Vec3(x, y, z) {
   _ASSERT && Vec3.assert(this);
 };
 
+Vec3.neo = function(x, y, z) {
+  var obj = Object.create(Vec3.prototype);
+  obj.x = x;
+  obj.y = y;
+  obj.z = z;
+  return obj;
+};
+
+Vec3.clone = function(v) {
+  _ASSERT && Vec3.assert(v);
+  return Vec3.neo(v.x, v.y, v.z);
+};
+
 Vec3.prototype.toString = function() {
   return JSON.stringify(this);
 };

--- a/lib/common/index.d.ts
+++ b/lib/common/index.d.ts
@@ -120,6 +120,8 @@ declare namespace planck {
     new(): Vec3;
     (): Vec3;
 
+    // neo(x: number, y: number, z: number): Vec3; internal
+    clone(v: Vec3): Vec3;
     areEqual(v: Vec3, w: Vec3): boolean;
     dot(v: Vec3, w: Vec3): number;
     cross(v: Vec3, w: Vec3): Vec3;
@@ -216,4 +218,60 @@ declare namespace planck {
     getInverse(): Mat22;
     solve(v: Vec2): Vec2;
   }
+
+  let Mat22: {
+    new(a: number, b: number, c: number, d: number): Mat22;
+    (a: number, b: number, c: number, d: number): Mat22;
+
+    new(a: { x: number; y: number }, b: { x: number; y: number }): Mat22;
+    (a: { x: number; y: number }, b: { x: number; y: number }): Mat22;
+
+    new(): Mat22;
+    (): Mat22;
+
+    isValid(o: any): boolean;
+    assert(o: any): void;
+
+    mul(mx: Mat22, my: Mat22): Mat22;
+    mul(mx: Mat22, v: Vec2): Vec2;
+    mulVec2(mx: Mat22, v: Vec2): Vec2;
+    mulMat22(mx: Mat22, my: Mat22): Mat22;
+    mulT(mx: Mat22, my: Mat22): Mat22;
+    mulT(mx: Mat22, v: Vec2): Vec2;
+    abs(mx): Mat22;
+    add(mx1, mx2): Mat22;
+  };
+
+  interface Mat33 {
+    ex: Vec3;
+    ey: Vec3;
+    ez: Vec3;
+
+    toString(): string;
+    setZero(): Mat33;
+    solve33(v: Vec3): Vec3;
+    solve22(v: Vec2): Vec2;
+    getInverse22(M: Mat33): void;
+    getSymInverse33(M: Mat33): void;
+  }
+
+  let Mat33: {
+    new(a: Vec3, b: Vec3, c: Vec3): Mat33;
+    (a: any, b: any, c: any): Mat33;
+
+    new(a: any, b: any, c: any): Mat33;
+    (a: any, b: any, c: any): Mat33;
+
+    new(): Mat33;
+    (): Mat33;
+
+    isValid(o: any): boolean;
+    assert(o: any): void;
+
+    mul(a: Mat33, b: Vec2): Vec2;
+    mul(a: Mat33, b: Vec3): Vec3;
+    mulVec3(a: Mat33, b: Vec3): Vec3;
+    mulVec2(a: Mat33, b: Vec2): Vec2;
+    add(a: Mat33, b: Mat33): Vec3;
+  };
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@ exports.internal = {};
 exports.Math = require('./common/Math');
 exports.Vec2 = require('./common/Vec2');
 exports.Vec3 = require('./common/Vec3');
+exports.Mat22 = require('./common/Mat22');
+exports.Mat33 = require('./common/Mat33');
 exports.Transform = require('./common/Transform');
 exports.Rot = require('./common/Rot');
 


### PR DESCRIPTION
Resolves #68 

While making the changes I noticed a few things:
- `Vec3` had no method `clone`, which meant that the `Mat33` constructor wouldn't work if the first parameter `a` was an object. I added a method to fix this.
- Some of the return typing is inconsistent (e.g. `add` in `Mat22` vs `Mat33`). Not sure what to do about this, suggestions?
- Some of the mocha tests fail, even before I changed anything