### PR TITLE
Use module declaration and let it compile with strict explicit any

### DIFF
--- a/lib/collision/index.d.ts
+++ b/lib/collision/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace planck {
+declare module "planck-js" {
   type BroadPhase = any; // TODO
 
   type RayCastInput = { // TODO interface?

--- a/lib/common/index.d.ts
+++ b/lib/common/index.d.ts
@@ -239,8 +239,8 @@ declare module "planck-js" {
     mulMat22(mx: Mat22, my: Mat22): Mat22;
     mulT(mx: Mat22, my: Mat22): Mat22;
     mulT(mx: Mat22, v: Vec2): Vec2;
-    abs(mx): Mat22;
-    add(mx1, mx2): Mat22;
+    abs(mx: Mat22): Mat22;
+    add(mx1: Mat22, mx2: Mat22): Mat22;
   };
 
   interface Mat33 {

--- a/lib/common/index.d.ts
+++ b/lib/common/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace planck {
+declare module "planck-js" {
   let Math: Math & {
     readonly EPSILON: number;
     /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference path="shape/index.d.ts" />
 /// <reference path="../testbed/index.d.ts" />
 
-declare namespace planck {
+declare module "planck-js" {
 
   type Manifold = any; // TODO
 

--- a/lib/joint/index.d.ts
+++ b/lib/joint/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace planck {
+declare module "planck-js" {
   // Types
 
   enum LIMIT_STATE {

--- a/lib/joint/index.d.ts
+++ b/lib/joint/index.d.ts
@@ -41,9 +41,9 @@ declare module "planck-js" {
     getReactionForce(inv_dt: number): Vec2;
     getReactionTorque(inv_dt: number): number;
     shiftOrigin(newOrigin: Vec2): void;
-    initVelocityConstraints(step): void;
-    solveVelocityConstraints(step): void;
-    solvePositionConstraints(step): boolean;
+    initVelocityConstraints(step: any): void;
+    solveVelocityConstraints(step: any): void;
+    solvePositionConstraints(step: any): boolean;
   }
   type JointOpt = Partial<{
     userData: any,

--- a/lib/shape/index.d.ts
+++ b/lib/shape/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace planck {
+declare module "planck-js" {
   // Types
   type ShapeType = "circle" | "edge" | "polygon" | "chain";
 

--- a/testbed/index.d.ts
+++ b/testbed/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace planck {
+declare module "planck-js" {
 
   interface Testbed {
     isPaused(): boolean;


### PR DESCRIPTION
When trying to use planck.js with Typescript, Webpack, and ES6 modules, we run into importing errors. After switching the ambient namespace declaration to an ambient module declaration, and adding some missing typing, it works.