### PR TITLE
Remove World import from Body

### DIFF
--- a/lib/Body.js
+++ b/lib/Body.js
@@ -35,7 +35,6 @@ var Position = require('./common/Position');
 
 var Fixture = require('./Fixture');
 var Shape = require('./Shape');
-var World = require('./World');
 
 var staticBody = Body.STATIC = 'static';
 var kinematicBody = Body.KINEMATIC = 'kinematic';


### PR DESCRIPTION
It's not used, and ends up with a circular dependency when it is in there. Removing it fixes the circular dependency.