### PR TITLE
Added TS types for Manifold and WorldManifold

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -14,10 +14,20 @@ export * from "./common";
 export * from "./joint";
 export * from "./shape";
 export * from "../testbed";
+  
+export interface Manifold {
+  type: number;
+  localNormal: Vec2;
+  localPoint: Vec2;
+  points: Vec2[];
+  pointCount: number;
+}
 
-export type Manifold = any; // TODO
-
-export type WorldManifold = any; // TODO
+export interface WorldManifold {
+  normal: Vec2;
+  points: Vec2[];
+  separations: number[];
+}
 
 export namespace Manifold {
   type Type = any;


### PR DESCRIPTION
Here are some more Typescript types.

I did not put the constructors such as:
```typescript
export let Manifold: {
  new(): Manifold;
};
```
as Manifold is an internal member.

In case it interests anyone: on our fork I will make Manifold public and add the constructors because I want to create a Manifold on my user code side to bypass Box2D's limitation of not getting an exact collision point for sensors.