### PR TITLE
Extend typings of planck.internal

### DIFF
--- a/lib/collision/index.d.ts
+++ b/lib/collision/index.d.ts
@@ -89,7 +89,3 @@ export interface DynamicTree {
     query(aabb: AABB, queryCallback: (id: string) => boolean): void;
     rayCast(input: RayCastInput, rayCastCallback: (subInput: RayCastInput, id: string) => number): void;
 }
-
-export let DynamicTree: {
-  new(): DynamicTree;
-};

--- a/lib/common/index.d.ts
+++ b/lib/common/index.d.ts
@@ -290,7 +290,3 @@ export interface Sweep {
   clone(): Sweep;
   set(sweep: Sweep): void;
 }
-
-export let Sweep: {
-    new(c, a): Sweep;
-};


### PR DESCRIPTION
Finally found time to add typings for `Distance` and `TimeOfImpact`.
I'm a bit surprised the `export` keyword doesn't seem to be required in the 'internal' namespace (I hope I'm not breaking things here 😅)