### PR TITLE
Fixed shapes' creation function declaration in TypeScript definition

### DIFF
--- a/lib/shape/index.d.ts
+++ b/lib/shape/index.d.ts
@@ -20,8 +20,8 @@ export class Shape {
   computeDistanceProxy(proxy: DistanceProxy): void;
 }
 
-export function CircleShape(position: Vec2, radius?: number): CircleShape;
-export function CircleShape(radius?: number): CircleShape;
+export function Circle(position: Vec2, radius?: number): CircleShape;
+export function Circle(radius?: number): CircleShape;
 export class CircleShape extends Shape {
   static TYPE: 'circle';
 
@@ -36,7 +36,7 @@ export class CircleShape extends Shape {
   getVertexCount(index?: number): 1;
 }
 
-export function EdgeShape(v1: Vec2, v2: Vec2): EdgeShape;
+export function Edge(v1: Vec2, v2: Vec2): EdgeShape;
 export class EdgeShape extends Shape {
   static TYPE: 'edge';
 
@@ -55,7 +55,7 @@ export class EdgeShape extends Shape {
   /** @internal */ _set(v1: Vec2, v2: Vec2): EdgeShape;
 }
 
-export function PolygonShape(vertices: Vec2[]): PolygonShape;
+export function Polygon(vertices: Vec2[]): PolygonShape;
 export class PolygonShape extends Shape {
   static TYPE: 'polygon';
 
@@ -75,12 +75,12 @@ export class PolygonShape extends Shape {
   /** @internal */ _setAsBox(hx: number, hy: number): void;
 }
 
-export function BoxShape(hx: number, hy: number, center?: Vec2, angle?: number): BoxShape;
+export function Box(hx: number, hy: number, center?: Vec2, angle?: number): BoxShape;
 export class BoxShape extends PolygonShape {
   constructor(hx: number, hy: number, center?: Vec2, angle?: number);
 }
 
-export function ChainShape(vertices: Vec2[], loop?: boolean): ChainShape;
+export function Chain(vertices: Vec2[], loop?: boolean): ChainShape;
 export class ChainShape extends Shape {
   static TYPE: 'chain';
 


### PR DESCRIPTION
Hello,

I recently updated the PlanckJS dependency of my project and it gave me problems with shapes.

Indeed the functions that are exposed to create shapes are:
```js
exports.Circle = __webpack_require__(23);
exports.Edge = __webpack_require__(24);
exports.Polygon = __webpack_require__(21);
exports.Chain = __webpack_require__(28);
exports.Box = __webpack_require__(45);
```
*source: dist/planck.js*

Which doesn't correspond to TypeScript definitions:

```ts
export function CircleShape(position: Vec2, radius?: number): CircleShape;
export function CircleShape(radius?: number): CircleShape;
// [...]
export function EdgeShape(v1: Vec2, v2: Vec2): EdgeShape;
// [...]
export function PolygonShape(vertices: Vec2[]): PolygonShape;
// [...]
export function BoxShape(hx: number, hy: number, center?: Vec2, angle?: number): BoxShape;
// [...]
export function ChainShape(vertices: Vec2[], loop?: boolean): ChainShape;
```
*source: lib/shape/index.d.ts*

This PR solves the problem.