### PR TITLE
fix a typo in a type declaration

### DIFF
--- a/lib/collision/index.d.ts
+++ b/lib/collision/index.d.ts
@@ -33,7 +33,7 @@ export class DistanceProxy {
 
 export function AABB(lower?: Vec2, upper?: Vec2): AABB;
 export class AABB {
-  constroctor(lower?: Vec2, upper?: Vec2);
+  constructor(lower?: Vec2, upper?: Vec2);
 
   isValid(o: any): boolean;
   assert(o: any): void;


### PR DESCRIPTION
The typescript compiler chokes on this, and refuses to compile.