### PR TITLE
Serializer types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ export {
   PolygonShape as Polygon,
   ChainShape as Chain,
 } from "./lib/shape";
+export * from "./lib/serializer";
 export * from "./lib";
 
 export * from "./testbed";

--- a/lib/serializer/index.d.ts
+++ b/lib/serializer/index.d.ts
@@ -1,0 +1,23 @@
+import { World } from "../";
+
+export interface SerializerDef<T = World> {
+  rootClass?: {
+    new(...args: any[]): T,
+  };
+
+  preSerialize?: (obj: object | any[]) => any;
+  postSerialize?: (data: any, obj: any) => any;
+
+  preDeserialize?: (data: any) => any;
+  postDeserialize?: (obj: any, data: any) => any;
+}
+
+export class Serializer<T> {
+  constructor(opts?: SerializerDef<T>)
+
+  toJson(root: T): any[]
+  fromJson(json: any[]): T
+
+  static toJson(root: World): any[]
+  static fromJson(json: any[]): World
+}


### PR DESCRIPTION
The serializer types are a bit imprecise. You can go a bit further like e.g. something like this
```typescript
import { World } from "../";

type serializable<U> = { _serialize(): U }

export interface SerializerDef<T extends serializable<any> = World> {
  rootClass?: {
    new(): T,
    _deserialize(data: any, context: any, restore?: (cls: { _deserialize(/* TODO */): any }, ref: any, ctx: any) => T): T
  };

  preSerialize?: (obj: (object | any[]) & serializable<any>) => serializable<any>;
  postSerialize?: (data: any, obj: serializable<any>) => any;

  preDeserialize?: (data: any) => any;
  postDeserialize?: (obj: any, data: any) => any;
}

export class Serializer<T extends { _serialize(): any }> {
  constructor(opts?: SerializerDef<T>)

  toJson(root: T): any[]
  fromJson(json: any[]): T

  static toJson(root: World): any[]
  static fromJson(json: any[]): World
}
```
But then you would also have to extend all classes by `_serialize` and `_deserialize` and I don't know if it really adds much value, but please tell me what you think 🙂 You could probably also go crazy with `infer` but I think the feature is probably too new (and also would not add much value)