### PR TITLE
index.d.ts: export top level Settings declaration

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -536,7 +536,7 @@ export class World {
 /**
  * Tuning constants based on meters-kilograms-seconds (MKS) units.
  */
-let Settings: {
+export let Settings: {
   // Collision
   /**
    * The maximum number of contact points between two convex shapes. Do not change


### PR DESCRIPTION
This was causing issues when using the 0.3.28 branch in a typescript context.

```
../planck.js/lib/index.d.ts:539:1 - error TS1046: Top-level declarations in \
.d.ts files must start with either a 'declare' or 'export' modifier.

539 let Settings: {
    ~~~
```