### PR TITLE
Reduce function overloading

### DIFF
--- a/src/__test__/Collision.test.ts
+++ b/src/__test__/Collision.test.ts
@@ -13,8 +13,8 @@ describe('Collision', function(): void {
     var r, o = new AABB();
     expect(o.isValid()).equal(true);
 
-    o.upperBound.set(10, 6);
-    o.lowerBound.set(6, 4);
+    o.upperBound.setNum(10, 6);
+    o.lowerBound.setNum(6, 4);
 
     r = o.getCenter();
     expect(r.x).equal(8);

--- a/src/__test__/Math.test.ts
+++ b/src/__test__/Math.test.ts
@@ -68,7 +68,7 @@ describe('Math', function(): void {
     r = Vec2.crossVec2Vec2(v, new Vec2(2, 3));
     expect(r).equal(0);
 
-    r = Vec2.crossVec2Number(v, 5);
+    r = Vec2.crossVec2Num(v, 5);
     expect(r.x).equal(15);
     expect(r.y).equal(-10);
 

--- a/src/__test__/Math.test.ts
+++ b/src/__test__/Math.test.ts
@@ -65,10 +65,10 @@ describe('Math', function(): void {
     r = Vec2.dot(v, new Vec2(2, 3));
     expect(r).equal(13);
 
-    r = Vec2.cross(v, new Vec2(2, 3));
+    r = Vec2.crossVec2Vec2(v, new Vec2(2, 3));
     expect(r).equal(0);
 
-    r = Vec2.cross(v, 5);
+    r = Vec2.crossVec2Number(v, 5);
     expect(r.x).equal(15);
     expect(r.y).equal(-10);
 

--- a/src/__test__/Math.test.ts
+++ b/src/__test__/Math.test.ts
@@ -28,7 +28,7 @@ describe('Math', function(): void {
     expect(v.x).equal(0);
     expect(v.y).equal(0);
 
-    v.set(3, 4);
+    v.setNum(3, 4);
     expect(v.x).equal(3);
     expect(v.y).equal(4);
     expect(v.length()).equal(5);
@@ -54,7 +54,7 @@ describe('Math', function(): void {
     expect(v.x).equal(5);
     expect(v.y).equal(5);
 
-    v.set(2, 3);
+    v.setNum(2, 3);
     expect(v.x).equal(2);
     expect(v.y).equal(3);
 

--- a/src/collision/AABB.ts
+++ b/src/collision/AABB.ts
@@ -64,12 +64,12 @@ export default class AABB {
     this.upperBound = Vec2.zero();
 
     if (typeof lower === 'object') {
-      this.lowerBound.set(lower);
+      this.lowerBound.setVec2(lower);
     }
     if (typeof upper === 'object') {
-      this.upperBound.set(upper);
+      this.upperBound.setVec2(upper);
     } else if (typeof lower === 'object') {
-      this.upperBound.set(lower);
+      this.upperBound.setVec2(lower);
     }
   }
 

--- a/src/collision/AABB.ts
+++ b/src/collision/AABB.ts
@@ -132,18 +132,18 @@ export default class AABB {
     const upperX = Math.max(upperB.x, upperA.x);
     const upperY = Math.max(upperB.y, upperA.y);
 
-    this.lowerBound.set(lowerX, lowerY);
-    this.upperBound.set(upperX, upperY);
+    this.lowerBound.setNum(lowerX, lowerY);
+    this.upperBound.setNum(upperX, upperY);
   }
 
   combinePoints(a: Vec2, b: Vec2): void {
-    this.lowerBound.set(Math.min(a.x, b.x), Math.min(a.y, b.y));
-    this.upperBound.set(Math.max(a.x, b.x), Math.max(a.y, b.y));
+    this.lowerBound.setNum(Math.min(a.x, b.x), Math.min(a.y, b.y));
+    this.upperBound.setNum(Math.max(a.x, b.x), Math.max(a.y, b.y));
   }
 
   set(aabb: AABB): void {
-    this.lowerBound.set(aabb.lowerBound.x, aabb.lowerBound.y);
-    this.upperBound.set(aabb.upperBound.x, aabb.upperBound.y);
+    this.lowerBound.setNum(aabb.lowerBound.x, aabb.lowerBound.y);
+    this.upperBound.setNum(aabb.upperBound.x, aabb.upperBound.y);
   }
 
   contains(aabb: AABB): boolean {

--- a/src/collision/Distance.ts
+++ b/src/collision/Distance.ts
@@ -420,10 +420,10 @@ class Simplex {
         const sgn = Vec2.crossVec2Vec2(e12, Vec2.neg(this.m_v1.w));
         if (sgn > 0.0) {
           // Origin is left of e12.
-          return Vec2.crossNumberVec2(1.0, e12);
+          return Vec2.crossNumVec2(1.0, e12);
         } else {
           // Origin is right of e12.
-          return Vec2.crossVec2Number(e12, 1.0);
+          return Vec2.crossVec2Num(e12, 1.0);
         }
       }
 

--- a/src/collision/Distance.ts
+++ b/src/collision/Distance.ts
@@ -218,8 +218,8 @@ export default function Distance(output: DistanceOutput, cache: SimplexCache, in
       // Shapes are overlapped when radii are considered.
       // Move the witness points to the middle.
       const p = Vec2.mid(output.pointA, output.pointB);
-      output.pointA.set(p);
-      output.pointB.set(p);
+      output.pointA.setVec2(p);
+      output.pointB.setVec2(p);
       output.distance = 0.0;
     }
   }
@@ -417,13 +417,13 @@ class Simplex {
 
       case 2: {
         const e12 = Vec2.sub(this.m_v2.w, this.m_v1.w);
-        const sgn = Vec2.cross(e12, Vec2.neg(this.m_v1.w));
+        const sgn = Vec2.crossVec2Vec2(e12, Vec2.neg(this.m_v1.w));
         if (sgn > 0.0) {
           // Origin is left of e12.
-          return Vec2.cross(1.0, e12);
+          return Vec2.crossNumberVec2(1.0, e12);
         } else {
           // Origin is right of e12.
-          return Vec2.cross(e12, 1.0);
+          return Vec2.crossVec2Number(e12, 1.0);
         }
       }
 
@@ -461,8 +461,8 @@ class Simplex {
         break;
 
       case 1:
-        pA.set(this.m_v1.wA);
-        pB.set(this.m_v1.wB);
+        pA.setVec2(this.m_v1.wA);
+        pB.setVec2(this.m_v1.wB);
         break;
 
       case 2:
@@ -473,7 +473,7 @@ class Simplex {
       case 3:
         pA.setCombine(this.m_v1.a, this.m_v1.wA, this.m_v2.a, this.m_v2.wA);
         pA.addMul(this.m_v3.a, this.m_v3.wA);
-        pB.set(pA);
+        pB.setVec2(pA);
         break;
 
       default:
@@ -495,7 +495,7 @@ class Simplex {
         return Vec2.distance(this.m_v1.w, this.m_v2.w);
 
       case 3:
-        return Vec2.cross(Vec2.sub(this.m_v2.w, this.m_v1.w), Vec2.sub(this.m_v3.w,
+        return Vec2.crossVec2Vec2(Vec2.sub(this.m_v2.w, this.m_v1.w), Vec2.sub(this.m_v3.w,
           this.m_v1.w));
 
       default:
@@ -617,11 +617,11 @@ class Simplex {
     const d23_2 = -w2e23;
 
     // Triangle123
-    const n123 = Vec2.cross(e12, e13);
+    const n123 = Vec2.crossVec2Vec2(e12, e13);
 
-    const d123_1 = n123 * Vec2.cross(w2, w3);
-    const d123_2 = n123 * Vec2.cross(w3, w1);
-    const d123_3 = n123 * Vec2.cross(w1, w2);
+    const d123_1 = n123 * Vec2.crossVec2Vec2(w2, w3);
+    const d123_2 = n123 * Vec2.crossVec2Vec2(w3, w1);
+    const d123_3 = n123 * Vec2.crossVec2Vec2(w1, w2);
 
     // w1 region
     if (d12_2 <= 0.0 && d13_2 <= 0.0) {

--- a/src/collision/DynamicTree.ts
+++ b/src/collision/DynamicTree.ts
@@ -794,7 +794,7 @@ export default class DynamicTree<T> {
     r.normalize();
 
     // v is perpendicular to the segment.
-    const v = Vec2.cross(1.0, r);
+    const v = Vec2.crossNumberVec2(1.0, r);
     const abs_v = Vec2.abs(v);
 
     // Separating axis for segment (Gino, p80).

--- a/src/collision/DynamicTree.ts
+++ b/src/collision/DynamicTree.ts
@@ -794,7 +794,7 @@ export default class DynamicTree<T> {
     r.normalize();
 
     // v is perpendicular to the segment.
-    const v = Vec2.crossNumberVec2(1.0, r);
+    const v = Vec2.crossNumVec2(1.0, r);
     const abs_v = Vec2.abs(v);
 
     // Separating axis for segment (Gino, p80).

--- a/src/collision/Manifold.ts
+++ b/src/collision/Manifold.ts
@@ -93,7 +93,7 @@ export default class Manifold {
         const pointB = Transform.mulVec2(xfB, this.points[0].localPoint);
         const dist = Vec2.sub(pointB, pointA);
         if (Vec2.lengthSquared(dist) > Math.EPSILON * Math.EPSILON) {
-          normal.set(dist);
+          normal.setVec2(dist);
           normal.normalize();
         }
         const cA = pointA.clone().addMul(radiusA, normal);
@@ -312,7 +312,7 @@ export class ClipVertex {
   id: ContactID = new ContactID();
 
   set(o: ClipVertex): void {
-    this.v.set(o.v);
+    this.v.setVec2(o.v);
     this.id.set(o.id);
   }
 }

--- a/src/collision/TimeOfImpact.ts
+++ b/src/collision/TimeOfImpact.ts
@@ -351,7 +351,7 @@ class SeparationFunction {
       const localPointB1 = proxyB.getVertex(cache.indexB[0]);
       const localPointB2 = proxyB.getVertex(cache.indexB[1]);
 
-      this.m_axis = Vec2.crossVec2Number(Vec2.sub(localPointB2, localPointB1), 1.0);
+      this.m_axis = Vec2.crossVec2Num(Vec2.sub(localPointB2, localPointB1), 1.0);
       this.m_axis.normalize();
       const normal = Rot.mulVec2(xfB.q, this.m_axis);
 
@@ -374,7 +374,7 @@ class SeparationFunction {
       const localPointA1 = this.m_proxyA.getVertex(cache.indexA[0]);
       const localPointA2 = this.m_proxyA.getVertex(cache.indexA[1]);
 
-      this.m_axis = Vec2.crossVec2Number(Vec2.sub(localPointA2, localPointA1), 1.0);
+      this.m_axis = Vec2.crossVec2Num(Vec2.sub(localPointA2, localPointA1), 1.0);
       this.m_axis.normalize();
       const normal = Rot.mulVec2(xfA.q, this.m_axis);
 

--- a/src/collision/TimeOfImpact.ts
+++ b/src/collision/TimeOfImpact.ts
@@ -351,7 +351,7 @@ class SeparationFunction {
       const localPointB1 = proxyB.getVertex(cache.indexB[0]);
       const localPointB2 = proxyB.getVertex(cache.indexB[1]);
 
-      this.m_axis = Vec2.cross(Vec2.sub(localPointB2, localPointB1), 1.0);
+      this.m_axis = Vec2.crossVec2Number(Vec2.sub(localPointB2, localPointB1), 1.0);
       this.m_axis.normalize();
       const normal = Rot.mulVec2(xfB.q, this.m_axis);
 
@@ -374,7 +374,7 @@ class SeparationFunction {
       const localPointA1 = this.m_proxyA.getVertex(cache.indexA[0]);
       const localPointA2 = this.m_proxyA.getVertex(cache.indexA[1]);
 
-      this.m_axis = Vec2.cross(Vec2.sub(localPointA2, localPointA1), 1.0);
+      this.m_axis = Vec2.crossVec2Number(Vec2.sub(localPointA2, localPointA1), 1.0);
       this.m_axis.normalize();
       const normal = Rot.mulVec2(xfA.q, this.m_axis);
 

--- a/src/collision/shape/CircleShape.ts
+++ b/src/collision/shape/CircleShape.ts
@@ -57,7 +57,7 @@ export default class CircleShape extends Shape {
     this.m_radius = 1;
 
     if (typeof a === 'object' && Vec2.isValid(a)) {
-      this.m_p.set(a);
+      this.m_p.setVec2(a);
 
       if (typeof b === 'number') {
         this.m_radius = b;
@@ -167,7 +167,7 @@ export default class CircleShape extends Shape {
     if (0.0 <= a && a <= input.maxFraction * rr) {
       a /= rr;
       output.fraction = a;
-      output.normal = Vec2.add(s, Vec2.mul(a, r));
+      output.normal = Vec2.add(s, Vec2.mulNumberVec2(a, r));
       output.normal.normalize();
       return true;
     }

--- a/src/collision/shape/CircleShape.ts
+++ b/src/collision/shape/CircleShape.ts
@@ -185,8 +185,8 @@ export default class CircleShape extends Shape {
    */
   computeAABB(aabb: AABB, xf: Transform, childIndex: number): void {
     const p = Vec2.add(xf.p, Rot.mulVec2(xf.q, this.m_p));
-    aabb.lowerBound.set(p.x - this.m_radius, p.y - this.m_radius);
-    aabb.upperBound.set(p.x + this.m_radius, p.y + this.m_radius);
+    aabb.lowerBound.setNum(p.x - this.m_radius, p.y - this.m_radius);
+    aabb.upperBound.setNum(p.x + this.m_radius, p.y + this.m_radius);
   }
 
   /**

--- a/src/collision/shape/CircleShape.ts
+++ b/src/collision/shape/CircleShape.ts
@@ -167,7 +167,7 @@ export default class CircleShape extends Shape {
     if (0.0 <= a && a <= input.maxFraction * rr) {
       a /= rr;
       output.fraction = a;
-      output.normal = Vec2.add(s, Vec2.mulNumberVec2(a, r));
+      output.normal = Vec2.add(s, Vec2.mulNumVec2(a, r));
       output.normal.normalize();
       return true;
     }

--- a/src/collision/shape/CollideCircle.ts
+++ b/src/collision/shape/CollideCircle.ts
@@ -58,10 +58,10 @@ export function CollideCircles(manifold: Manifold, circleA: CircleShape, xfA: Tr
   }
 
   manifold.type = ManifoldType.e_circles;
-  manifold.localPoint.set(circleA.m_p);
+  manifold.localPoint.setVec2(circleA.m_p);
   manifold.localNormal.setZero();
   manifold.pointCount = 1;
-  manifold.points[0].localPoint.set(circleB.m_p);
+  manifold.points[0].localPoint.setVec2(circleB.m_p);
 
   // manifold.points[0].id.key = 0;
   manifold.points[0].id.cf.indexA = 0;

--- a/src/collision/shape/CollideCirclePolygone.ts
+++ b/src/collision/shape/CollideCirclePolygone.ts
@@ -83,7 +83,7 @@ export function CollidePolygonCircle(manifold: Manifold, polygonA: PolygonShape,
   if (separation < Math.EPSILON) {
     manifold.pointCount = 1;
     manifold.type = ManifoldType.e_faceA;
-    manifold.localNormal.set(normals[normalIndex]);
+    manifold.localNormal.setVec2(normals[normalIndex]);
     manifold.localPoint.setCombine(0.5, v1, 0.5, v2);
     manifold.points[0].localPoint = circleB.m_p;
 
@@ -108,7 +108,7 @@ export function CollidePolygonCircle(manifold: Manifold, polygonA: PolygonShape,
     manifold.localNormal.setCombine(1, cLocal, -1, v1);
     manifold.localNormal.normalize();
     manifold.localPoint = v1;
-    manifold.points[0].localPoint.set(circleB.m_p);
+    manifold.points[0].localPoint.setVec2(circleB.m_p);
 
     // manifold.points[0].id.key = 0;
     manifold.points[0].id.cf.indexA = 0;
@@ -124,8 +124,8 @@ export function CollidePolygonCircle(manifold: Manifold, polygonA: PolygonShape,
     manifold.type = ManifoldType.e_faceA;
     manifold.localNormal.setCombine(1, cLocal, -1, v2);
     manifold.localNormal.normalize();
-    manifold.localPoint.set(v2);
-    manifold.points[0].localPoint.set(circleB.m_p);
+    manifold.localPoint.setVec2(v2);
+    manifold.points[0].localPoint.setVec2(circleB.m_p);
 
     // manifold.points[0].id.key = 0;
     manifold.points[0].id.cf.indexA = 0;
@@ -141,9 +141,9 @@ export function CollidePolygonCircle(manifold: Manifold, polygonA: PolygonShape,
 
     manifold.pointCount = 1;
     manifold.type = ManifoldType.e_faceA;
-    manifold.localNormal.set(normals[vertIndex1]);
-    manifold.localPoint.set(faceCenter);
-    manifold.points[0].localPoint.set(circleB.m_p);
+    manifold.localNormal.setVec2(normals[vertIndex1]);
+    manifold.localPoint.setVec2(faceCenter);
+    manifold.points[0].localPoint.setVec2(circleB.m_p);
 
     // manifold.points[0].id.key = 0;
     manifold.points[0].id.cf.indexA = 0;

--- a/src/collision/shape/CollideEdgeCircle.ts
+++ b/src/collision/shape/CollideEdgeCircle.ts
@@ -105,9 +105,9 @@ export function CollideEdgeCircle(manifold: Manifold, edgeA: EdgeShape, xfA: Tra
 
     manifold.type = ManifoldType.e_circles;
     manifold.localNormal.setZero();
-    manifold.localPoint.set(P);
+    manifold.localPoint.setVec2(P);
     manifold.pointCount = 1;
-    manifold.points[0].localPoint.set(circleB.m_p);
+    manifold.points[0].localPoint.setVec2(circleB.m_p);
 
     // manifold.points[0].id.key = 0;
     manifold.points[0].id.cf.indexA = 0;
@@ -141,9 +141,9 @@ export function CollideEdgeCircle(manifold: Manifold, edgeA: EdgeShape, xfA: Tra
 
     manifold.type = ManifoldType.e_circles;
     manifold.localNormal.setZero();
-    manifold.localPoint.set(P);
+    manifold.localPoint.setVec2(P);
     manifold.pointCount = 1;
-    manifold.points[0].localPoint.set(circleB.m_p);
+    manifold.points[0].localPoint.setVec2(circleB.m_p);
 
     // manifold.points[0].id.key = 0;
     manifold.points[0].id.cf.indexA = 1;
@@ -171,9 +171,9 @@ export function CollideEdgeCircle(manifold: Manifold, edgeA: EdgeShape, xfA: Tra
 
   manifold.type = ManifoldType.e_faceA;
   manifold.localNormal = n;
-  manifold.localPoint.set(A);
+  manifold.localPoint.setVec2(A);
   manifold.pointCount = 1;
-  manifold.points[0].localPoint.set(circleB.m_p);
+  manifold.points[0].localPoint.setVec2(circleB.m_p);
 
   // manifold.points[0].id.key = 0;
   manifold.points[0].id.cf.indexA = 0;

--- a/src/collision/shape/CollideEdgeCircle.ts
+++ b/src/collision/shape/CollideEdgeCircle.ts
@@ -165,7 +165,7 @@ export function CollideEdgeCircle(manifold: Manifold, edgeA: EdgeShape, xfA: Tra
 
   const n = Vec2.neo(-e.y, e.x);
   if (Vec2.dot(n, Vec2.sub(Q, A)) < 0.0) {
-    n.set(-n.x, -n.y);
+    n.setNum(-n.x, -n.y);
   }
   n.normalize();
 

--- a/src/collision/shape/CollideEdgePolygon.ts
+++ b/src/collision/shape/CollideEdgePolygon.ts
@@ -444,7 +444,7 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     rf.normal.setVec2(polygonBA.normals[rf.i1]);
   }
 
-  rf.sideNormal1.set(rf.normal.y, -rf.normal.x);
+  rf.sideNormal1.setNum(rf.normal.y, -rf.normal.x);
   rf.sideNormal2.setMul(-1, rf.sideNormal1);
   rf.sideOffset1 = Vec2.dot(rf.sideNormal1, rf.v1);
   rf.sideOffset2 = Vec2.dot(rf.sideNormal2, rf.v2);

--- a/src/collision/shape/CollideEdgePolygon.ts
+++ b/src/collision/shape/CollideEdgePolygon.ts
@@ -486,7 +486,7 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
       const cp = manifold.points[pointCount]; // ManifoldPoint
 
       if (primaryAxis.type == EPAxisType.e_edgeA) {
-        cp.localPoint = Transform.mulT(xf, clipPoints2[i].v);
+        cp.localPoint = Transform.mulTVec2(xf, clipPoints2[i].v);
         cp.id = clipPoints2[i].id;
       } else {
         cp.localPoint = clipPoints2[i].v;

--- a/src/collision/shape/CollideEdgePolygon.ts
+++ b/src/collision/shape/CollideEdgePolygon.ts
@@ -159,7 +159,7 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     const edge0 = Vec2.sub(v1, v0);
     edge0.normalize();
     normal0 = Vec2.neo(edge0.y, -edge0.x);
-    convex1 = Vec2.cross(edge0, edge1) >= 0.0;
+    convex1 = Vec2.crossVec2Vec2(edge0, edge1) >= 0.0;
     offset0 = Vec2.dot(normal0, centroidB) - Vec2.dot(normal0, v0);
   }
 
@@ -168,7 +168,7 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     const edge2 = Vec2.sub(v3, v2);
     edge2.normalize();
     normal2 = Vec2.neo(edge2.y, -edge2.x);
-    convex2 = Vec2.cross(edge1, edge2) > 0.0;
+    convex2 = Vec2.crossVec2Vec2(edge1, edge2) > 0.0;
     offset2 = Vec2.dot(normal2, centroidB) - Vec2.dot(normal2, v2);
   }
 
@@ -182,9 +182,9 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     if (convex1 && convex2) {
       front = offset0 >= 0.0 || offset1 >= 0.0 || offset2 >= 0.0;
       if (front) {
-        normal.set(normal1);
-        lowerLimit.set(normal0);
-        upperLimit.set(normal2);
+        normal.setVec2(normal1);
+        lowerLimit.setVec2(normal0);
+        upperLimit.setVec2(normal2);
       } else {
         normal.setMul(-1, normal1);
         lowerLimit.setMul(-1, normal1);
@@ -193,9 +193,9 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     } else if (convex1) {
       front = offset0 >= 0.0 || (offset1 >= 0.0 && offset2 >= 0.0);
       if (front) {
-        normal.set(normal1);
-        lowerLimit.set(normal0);
-        upperLimit.set(normal1);
+        normal.setVec2(normal1);
+        lowerLimit.setVec2(normal0);
+        upperLimit.setVec2(normal1);
       } else {
         normal.setMul(-1, normal1);
         lowerLimit.setMul(-1, normal2);
@@ -204,9 +204,9 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     } else if (convex2) {
       front = offset2 >= 0.0 || (offset0 >= 0.0 && offset1 >= 0.0);
       if (front) {
-        normal.set(normal1);
-        lowerLimit.set(normal1);
-        upperLimit.set(normal2);
+        normal.setVec2(normal1);
+        lowerLimit.setVec2(normal1);
+        upperLimit.setVec2(normal2);
       } else {
         normal.setMul(-1, normal1);
         lowerLimit.setMul(-1, normal1);
@@ -215,9 +215,9 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     } else {
       front = offset0 >= 0.0 && offset1 >= 0.0 && offset2 >= 0.0;
       if (front) {
-        normal.set(normal1);
-        lowerLimit.set(normal1);
-        upperLimit.set(normal1);
+        normal.setVec2(normal1);
+        lowerLimit.setVec2(normal1);
+        upperLimit.setVec2(normal1);
       } else {
         normal.setMul(-1, normal1);
         lowerLimit.setMul(-1, normal2);
@@ -228,23 +228,23 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     if (convex1) {
       front = offset0 >= 0.0 || offset1 >= 0.0;
       if (front) {
-        normal.set(normal1);
-        lowerLimit.set(normal0);
+        normal.setVec2(normal1);
+        lowerLimit.setVec2(normal0);
         upperLimit.setMul(-1, normal1);
       } else {
         normal.setMul(-1, normal1);
-        lowerLimit.set(normal1);
+        lowerLimit.setVec2(normal1);
         upperLimit.setMul(-1, normal1);
       }
     } else {
       front = offset0 >= 0.0 && offset1 >= 0.0;
       if (front) {
-        normal.set(normal1);
-        lowerLimit.set(normal1);
+        normal.setVec2(normal1);
+        lowerLimit.setVec2(normal1);
         upperLimit.setMul(-1, normal1);
       } else {
         normal.setMul(-1, normal1);
-        lowerLimit.set(normal1);
+        lowerLimit.setVec2(normal1);
         upperLimit.setMul(-1, normal0);
       }
     }
@@ -252,36 +252,36 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     if (convex2) {
       front = offset1 >= 0.0 || offset2 >= 0.0;
       if (front) {
-        normal.set(normal1);
+        normal.setVec2(normal1);
         lowerLimit.setMul(-1, normal1);
-        upperLimit.set(normal2);
+        upperLimit.setVec2(normal2);
       } else {
         normal.setMul(-1, normal1);
         lowerLimit.setMul(-1, normal1);
-        upperLimit.set(normal1);
+        upperLimit.setVec2(normal1);
       }
     } else {
       front = offset1 >= 0.0 && offset2 >= 0.0;
       if (front) {
-        normal.set(normal1);
+        normal.setVec2(normal1);
         lowerLimit.setMul(-1, normal1);
-        upperLimit.set(normal1);
+        upperLimit.setVec2(normal1);
       } else {
         normal.setMul(-1, normal1);
         lowerLimit.setMul(-1, normal2);
-        upperLimit.set(normal1);
+        upperLimit.setVec2(normal1);
       }
     }
   } else {
     front = offset1 >= 0.0;
     if (front) {
-      normal.set(normal1);
+      normal.setVec2(normal1);
       lowerLimit.setMul(-1, normal1);
       upperLimit.setMul(-1, normal1);
     } else {
       normal.setMul(-1, normal1);
-      lowerLimit.set(normal1);
-      upperLimit.set(normal1);
+      lowerLimit.setVec2(normal1);
+      upperLimit.setVec2(normal1);
     }
   }
 
@@ -414,7 +414,7 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
       rf.i2 = 1;
       rf.v1 = v1;
       rf.v2 = v2;
-      rf.normal.set(normal1);
+      rf.normal.setVec2(normal1);
     } else {
       rf.i1 = 1;
       rf.i2 = 0;
@@ -441,7 +441,7 @@ export function CollideEdgePolygon(manifold: Manifold, edgeA: EdgeShape, xfA: Tr
     rf.i2 = rf.i1 + 1 < polygonBA.count ? rf.i1 + 1 : 0;
     rf.v1 = polygonBA.vertices[rf.i1];
     rf.v2 = polygonBA.vertices[rf.i2];
-    rf.normal.set(polygonBA.normals[rf.i1]);
+    rf.normal.setVec2(polygonBA.normals[rf.i1]);
   }
 
   rf.sideNormal1.set(rf.normal.y, -rf.normal.x);

--- a/src/collision/shape/CollidePolygon.ts
+++ b/src/collision/shape/CollidePolygon.ts
@@ -200,11 +200,11 @@ export function CollidePolygons(manifold: Manifold, polyA: PolygonShape, xfA: Tr
   const localTangent = Vec2.sub(v12, v11);
   localTangent.normalize();
 
-  const localNormal = Vec2.crossVec2Number(localTangent, 1.0);
+  const localNormal = Vec2.crossVec2Num(localTangent, 1.0);
   const planePoint = Vec2.combine(0.5, v11, 0.5, v12);
 
   const tangent = Rot.mulVec2(xf1.q, localTangent);
-  const normal = Vec2.crossVec2Number(tangent, 1.0);
+  const normal = Vec2.crossVec2Num(tangent, 1.0);
 
   v11 = Transform.mulVec2(xf1, v11);
   v12 = Transform.mulVec2(xf1, v12);

--- a/src/collision/shape/CollidePolygon.ts
+++ b/src/collision/shape/CollidePolygon.ts
@@ -200,11 +200,11 @@ export function CollidePolygons(manifold: Manifold, polyA: PolygonShape, xfA: Tr
   const localTangent = Vec2.sub(v12, v11);
   localTangent.normalize();
 
-  const localNormal = Vec2.cross(localTangent, 1.0);
+  const localNormal = Vec2.crossVec2Number(localTangent, 1.0);
   const planePoint = Vec2.combine(0.5, v11, 0.5, v12);
 
   const tangent = Rot.mulVec2(xf1.q, localTangent);
-  const normal = Vec2.cross(tangent, 1.0);
+  const normal = Vec2.crossVec2Number(tangent, 1.0);
 
   v11 = Transform.mulVec2(xf1, v11);
   v12 = Transform.mulVec2(xf1, v12);
@@ -245,7 +245,7 @@ export function CollidePolygons(manifold: Manifold, polyA: PolygonShape, xfA: Tr
 
     if (separation <= totalRadius) {
       const cp = manifold.points[pointCount];
-      cp.localPoint.set(Transform.mulTVec2(xf2, clipPoints2[i].v));
+      cp.localPoint.setVec2(Transform.mulTVec2(xf2, clipPoints2[i].v));
       cp.id = clipPoints2[i].id;
       if (flip) {
         // Swap features

--- a/src/collision/shape/CollidePolygon.ts
+++ b/src/collision/shape/CollidePolygon.ts
@@ -98,7 +98,7 @@ function findIncidentEdge(c: ClipVertex[], poly1: PolygonShape, xf1: Transform, 
   _ASSERT && common.assert(0 <= edge1 && edge1 < poly1.m_count);
 
   // Get the normal of the reference edge in poly2's frame.
-  const normal1 = Rot.mulT(xf2.q, Rot.mulVec2(xf1.q, normals1[edge1]));
+  const normal1 = Rot.mulTVec2(xf2.q, Rot.mulVec2(xf1.q, normals1[edge1]));
 
   // Find the incident edge on poly2.
   let index = 0;

--- a/src/collision/shape/EdgeShape.ts
+++ b/src/collision/shape/EdgeShape.ts
@@ -240,7 +240,7 @@ export default class EdgeShape extends Shape {
       return false;
     }
 
-    const q = Vec2.add(p1, Vec2.mulNumberVec2(t, d));
+    const q = Vec2.add(p1, Vec2.mulNumVec2(t, d));
 
     // q = v1 + s * r
     // s = dot(q - v1, r) / dot(r, r)

--- a/src/collision/shape/EdgeShape.ts
+++ b/src/collision/shape/EdgeShape.ts
@@ -108,7 +108,7 @@ export default class EdgeShape extends Shape {
    */
   setNextVertex(v?: Vec2): EdgeShape {
     if (v) {
-      this.m_vertex3.set(v);
+      this.m_vertex3.setVec2(v);
       this.m_hasVertex3 = true;
     } else {
       this.m_vertex3.setZero();
@@ -134,7 +134,7 @@ export default class EdgeShape extends Shape {
    */
   setPrevVertex(v?: Vec2): EdgeShape {
     if (v) {
-      this.m_vertex0.set(v);
+      this.m_vertex0.setVec2(v);
       this.m_hasVertex0 = true;
     } else {
       this.m_vertex0.setZero();
@@ -154,8 +154,8 @@ export default class EdgeShape extends Shape {
    * Set this as an isolated edge.
    */
   _set(v1: Vec2, v2: Vec2): EdgeShape {
-    this.m_vertex1.set(v1);
-    this.m_vertex2.set(v2);
+    this.m_vertex1.setVec2(v1);
+    this.m_vertex2.setVec2(v2);
     this.m_hasVertex0 = false;
     this.m_hasVertex3 = false;
     return this;
@@ -171,10 +171,10 @@ export default class EdgeShape extends Shape {
     const clone = new EdgeShape();
     clone.m_type = this.m_type;
     clone.m_radius = this.m_radius;
-    clone.m_vertex1.set(this.m_vertex1);
-    clone.m_vertex2.set(this.m_vertex2);
-    clone.m_vertex0.set(this.m_vertex0);
-    clone.m_vertex3.set(this.m_vertex3);
+    clone.m_vertex1.setVec2(this.m_vertex1);
+    clone.m_vertex2.setVec2(this.m_vertex2);
+    clone.m_vertex0.setVec2(this.m_vertex0);
+    clone.m_vertex3.setVec2(this.m_vertex3);
     clone.m_hasVertex0 = this.m_hasVertex0;
     clone.m_hasVertex3 = this.m_hasVertex3;
     return clone;
@@ -240,7 +240,7 @@ export default class EdgeShape extends Shape {
       return false;
     }
 
-    const q = Vec2.add(p1, Vec2.mul(t, d));
+    const q = Vec2.add(p1, Vec2.mulNumberVec2(t, d));
 
     // q = v1 + s * r
     // s = dot(q - v1, r) / dot(r, r)

--- a/src/collision/shape/PolygonShape.ts
+++ b/src/collision/shape/PolygonShape.ts
@@ -278,7 +278,7 @@ export default class PolygonShape extends Shape {
 
       const xf = Transform.identity();
       xf.p.setVec2(center);
-      xf.q.set(angle);
+      xf.q.setAngle(angle);
 
       // Transform vertices and normals.
       for (let i = 0; i < this.m_count; ++i) {

--- a/src/collision/shape/PolygonShape.ts
+++ b/src/collision/shape/PolygonShape.ts
@@ -397,8 +397,8 @@ export default class PolygonShape extends Shape {
       maxY = Math.max(maxY, v.y);
     }
 
-    aabb.lowerBound.set(minX, minY);
-    aabb.upperBound.set(maxX, maxY);
+    aabb.lowerBound.setNum(minX, minY);
+    aabb.upperBound.setNum(maxX, maxY);
     aabb.extend(this.m_radius);
   }
 

--- a/src/collision/shape/PolygonShape.ts
+++ b/src/collision/shape/PolygonShape.ts
@@ -248,7 +248,7 @@ export default class PolygonShape extends Shape {
       const i2 = i + 1 < m ? i + 1 : 0;
       const edge = Vec2.sub(this.m_vertices[i2], this.m_vertices[i1]);
       _ASSERT && common.assert(edge.lengthSquared() > Math.EPSILON * Math.EPSILON);
-      this.m_normals[i] = Vec2.crossVec2Number(edge, 1.0);
+      this.m_normals[i] = Vec2.crossVec2Num(edge, 1.0);
       this.m_normals[i].normalize();
     }
 

--- a/src/collision/shape/PolygonShape.ts
+++ b/src/collision/shape/PolygonShape.ts
@@ -110,7 +110,7 @@ export default class PolygonShape extends Shape {
     clone.m_type = this.m_type;
     clone.m_radius = this.m_radius;
     clone.m_count = this.m_count;
-    clone.m_centroid.set(this.m_centroid);
+    clone.m_centroid.setVec2(this.m_centroid);
     for (let i = 0; i < this.m_count; i++) {
       clone.m_vertices.push(this.m_vertices[i].clone());
     }
@@ -207,7 +207,7 @@ export default class PolygonShape extends Shape {
 
         const r = Vec2.sub(ps[ie], ps[hull[m]]);
         const v = Vec2.sub(ps[j], ps[hull[m]]);
-        const c = Vec2.cross(r, v);
+        const c = Vec2.crossVec2Vec2(r, v);
         // c < 0 means counter-clockwise wrapping, c > 0 means clockwise wrapping
         if (c < 0.0) {
           ie = j;
@@ -248,7 +248,7 @@ export default class PolygonShape extends Shape {
       const i2 = i + 1 < m ? i + 1 : 0;
       const edge = Vec2.sub(this.m_vertices[i2], this.m_vertices[i1]);
       _ASSERT && common.assert(edge.lengthSquared() > Math.EPSILON * Math.EPSILON);
-      this.m_normals[i] = Vec2.cross(edge, 1.0);
+      this.m_normals[i] = Vec2.crossVec2Number(edge, 1.0);
       this.m_normals[i].normalize();
     }
 
@@ -274,10 +274,10 @@ export default class PolygonShape extends Shape {
     if (Vec2.isValid(center)) {
       angle = angle || 0;
 
-      this.m_centroid.set(center);
+      this.m_centroid.setVec2(center);
 
       const xf = Transform.identity();
-      xf.p.set(center);
+      xf.p.setVec2(center);
       xf.q.set(angle);
 
       // Transform vertices and normals.
@@ -457,7 +457,7 @@ export default class PolygonShape extends Shape {
       const e1 = Vec2.sub(this.m_vertices[i], s);
       const e2 = i + 1 < this.m_count ? Vec2.sub(this.m_vertices[i + 1], s) : Vec2 .sub(this.m_vertices[0], s);
 
-      const D = Vec2.cross(e1, e2);
+      const D = Vec2.crossVec2Vec2(e1, e2);
 
       const triangleArea = 0.5 * D;
       area += triangleArea;
@@ -508,7 +508,7 @@ export default class PolygonShape extends Shape {
         }
 
         const v = Vec2.sub(this.m_vertices[j], p);
-        const c = Vec2.cross(e, v);
+        const c = Vec2.crossVec2Vec2(e, v);
         if (c < 0.0) {
           return false;
         }
@@ -553,7 +553,7 @@ function ComputeCentroid(vs: Vec2[], count: number): Vec2 {
     const e1 = Vec2.sub(p2, p1);
     const e2 = Vec2.sub(p3, p1);
 
-    const D = Vec2.cross(e1, e2);
+    const D = Vec2.crossVec2Vec2(e1, e2);
 
     const triangleArea = 0.5 * D;
     area += triangleArea;

--- a/src/common/Mat22.ts
+++ b/src/common/Mat22.ts
@@ -81,8 +81,8 @@ export default class Mat22 {
   set(a, b?, c?, d?): void {
     if (typeof a === 'number' && typeof b === 'number' && typeof c === 'number'
       && typeof d === 'number') {
-      this.ex.set(a, c);
-      this.ey.set(b, d);
+      this.ex.setNum(a, c);
+      this.ey.setNum(b, d);
 
     } else if (typeof a === 'object' && typeof b === 'object') {
       this.ex.setVec2(a);

--- a/src/common/Mat22.ts
+++ b/src/common/Mat22.ts
@@ -85,13 +85,13 @@ export default class Mat22 {
       this.ey.set(b, d);
 
     } else if (typeof a === 'object' && typeof b === 'object') {
-      this.ex.set(a);
-      this.ey.set(b);
+      this.ex.setVec2(a);
+      this.ey.setVec2(b);
 
     } else if (typeof a === 'object') {
       _ASSERT && Mat22.assert(a);
-      this.ex.set(a.ex);
-      this.ey.set(a.ey);
+      this.ex.setVec2(a.ex);
+      this.ey.setVec2(a.ey);
 
     } else {
       _ASSERT && common.assert(false);

--- a/src/common/Rot.ts
+++ b/src/common/Rot.ts
@@ -43,7 +43,7 @@ export default class Rot {
     if (typeof angle === 'number') {
       this.setAngle(angle);
     } else if (typeof angle === 'object') {
-      this.set(angle);
+      this.setRot(angle);
     } else {
       this.setIdentity();
     }
@@ -106,6 +106,12 @@ export default class Rot {
     }
   }
 
+  setRot(angle: Rot): void {
+    _ASSERT && Rot.assert(angle);
+    this.s = angle.s;
+    this.c = angle.c;
+  }
+
   /** Set using an angle in radians. */
   setAngle(angle: number): void {
     _ASSERT && Math.assert(angle);
@@ -153,6 +159,7 @@ export default class Rot {
     }
   }
 
+  /** Multiply two rotations: q * r */
   static mulRot(rot: Rot, m: Rot): Rot {
     _ASSERT && Rot.assert(rot);
     _ASSERT && Rot.assert(m);
@@ -166,6 +173,7 @@ export default class Rot {
     return qr;
   }
 
+  /** Rotate a vector */
   static mulVec2(rot: Rot, m: Vec2): Vec2 {
     _ASSERT && Rot.assert(rot);
     _ASSERT && Vec2.assert(m);
@@ -201,6 +209,7 @@ export default class Rot {
     }
   }
 
+  /** Transpose multiply two rotations: qT * r */
   static mulTRot(rot: Rot, m: Rot): Rot {
     _ASSERT && Rot.assert(m);
     // [ qc qs] * [rc -rs] = [qc*rc+qs*rs -qc*rs+qs*rc]
@@ -213,6 +222,7 @@ export default class Rot {
     return qr;
   }
 
+  /** Inverse rotate a vector */
   static mulTVec2(rot: Rot, m: Vec2): Vec2 {
     _ASSERT && Vec2.assert(m);
     return Vec2.neo(rot.c * m.x + rot.s * m.y, -rot.s * m.x + rot.c * m.y);

--- a/src/common/Sweep.ts
+++ b/src/common/Sweep.ts
@@ -67,19 +67,19 @@ export default class Sweep {
 
   setTransform(xf: Transform): void {
     const c = Transform.mulVec2(xf, this.localCenter);
-    this.c.set(c);
-    this.c0.set(c);
+    this.c.setVec2(c);
+    this.c0.setVec2(c);
 
     this.a = xf.q.getAngle();
     this.a0 = xf.q.getAngle();
   }
 
   setLocalCenter(localCenter: Vec2, xf: Transform): void {
-    this.localCenter.set(localCenter);
+    this.localCenter.setVec2(localCenter);
 
     const c = Transform.mulVec2(xf, this.localCenter);
-    this.c.set(c);
-    this.c0.set(c);
+    this.c.setVec2(c);
+    this.c0.setVec2(c);
   }
 
   /**
@@ -112,7 +112,7 @@ export default class Sweep {
 
   forward(): void {
     this.a0 = this.a;
-    this.c0.set(this.c);
+    this.c0.setVec2(this.c);
   }
 
   /**
@@ -126,21 +126,21 @@ export default class Sweep {
 
   clone(): Sweep {
     const clone = new Sweep();
-    clone.localCenter.set(this.localCenter);
+    clone.localCenter.setVec2(this.localCenter);
     clone.alpha0 = this.alpha0;
     clone.a0 = this.a0;
     clone.a = this.a;
-    clone.c0.set(this.c0);
-    clone.c.set(this.c);
+    clone.c0.setVec2(this.c0);
+    clone.c.setVec2(this.c);
     return clone;
   }
 
   set(that: Sweep): void {
-    this.localCenter.set(that.localCenter);
+    this.localCenter.setVec2(that.localCenter);
     this.alpha0 = that.alpha0;
     this.a0 = that.a0;
     this.a = that.a;
-    this.c0.set(that.c0);
-    this.c.set(that.c);
+    this.c0.setVec2(that.c0);
+    this.c.setVec2(that.c);
   }
 }

--- a/src/common/Sweep.ts
+++ b/src/common/Sweep.ts
@@ -88,8 +88,7 @@ export default class Sweep {
    * @param xf
    * @param beta A factor in [0,1], where 0 indicates alpha0
    */
-  getTransform(xf: Transform, beta: number): void {
-    beta = typeof beta === 'undefined' ? 0 : beta;
+  getTransform(xf: Transform, beta: number = 0): void {
     xf.q.setAngle((1.0 - beta) * this.a0 + beta * this.a);
     xf.p.setCombine((1.0 - beta), this.c0, beta, this.c);
 

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -87,20 +87,17 @@ export default class Transform {
     this.q.setIdentity();
   }
 
-  set(position: Vec2, rotation: number): void;
-  set(xf: Transform): void;
   /**
    * Set this based on the position and angle.
    */
-  // tslint:disable-next-line:typedef
-  set(a, b?) {
-    if (typeof b === 'undefined') {
-      this.p.setVec2(a.p);
-      this.q.setRot(a.q);
-    } else {
-      this.p.setVec2(a);
-      this.q.setAngle(b);
-    }
+  set(position: Vec2, rotation: number) {
+    this.p.setVec2(position);
+    this.q.setAngle(rotation);
+  }
+
+  setTransform(xf: Transform): void {
+    this.p.setVec2(xf.p);
+    this.q.setRot(xf.q);
   }
 
   static isValid(obj: any): boolean {

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -87,10 +87,26 @@ export default class Transform {
     this.q.setIdentity();
   }
 
+  set(position: Vec2, rotation: number): void;
+  set(xf: Transform): void;
   /**
    * Set this based on the position and angle.
    */
-  set(position: Vec2, rotation: number) {
+  // tslint:disable-next-line:typedef
+  set(a, b?) {
+    if (typeof b === 'undefined') {
+      this.p.set(a.p);
+      this.q.set(a.q);
+    } else {
+      this.p.set(a);
+      this.q.set(b);
+    }
+  }
+
+  /**
+   * Set this based on the position and angle.
+   */
+  setNum(position: Vec2, rotation: number) {
     this.p.setVec2(position);
     this.q.setAngle(rotation);
   }

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -53,7 +53,7 @@ export default class Transform {
       this.p.setVec2(position);
     }
     if (typeof rotation !== 'undefined') {
-      this.q.set(rotation);
+      this.q.setAngle(rotation);
     }
   }
 
@@ -96,10 +96,10 @@ export default class Transform {
   set(a, b?) {
     if (typeof b === 'undefined') {
       this.p.setVec2(a.p);
-      this.q.set(a.q);
+      this.q.setRot(a.q);
     } else {
       this.p.setVec2(a);
-      this.q.set(b);
+      this.q.setAngle(b);
     }
   }
 
@@ -208,7 +208,7 @@ export default class Transform {
     // v2 = A.q' * (B.q * v1 + B.p - A.p)
     // = A.q' * B.q * v1 + A.q' * (B.p - A.p)
     const xf = Transform.identity();
-    xf.q.set(Rot.mulTRot(a.q, b.q));
+    xf.q.setRot(Rot.mulTRot(a.q, b.q));
     xf.p.setVec2(Rot.mulTVec2(a.q, Vec2.sub(b.p, a.p)));
     return xf;
   }

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -50,7 +50,7 @@ export default class Transform {
     this.p = Vec2.zero();
     this.q = Rot.identity();
     if (typeof position !== 'undefined') {
-      this.p.set(position);
+      this.p.setVec2(position);
     }
     if (typeof rotation !== 'undefined') {
       this.q.set(rotation);
@@ -95,10 +95,10 @@ export default class Transform {
   // tslint:disable-next-line:typedef
   set(a, b?) {
     if (typeof b === 'undefined') {
-      this.p.set(a.p);
+      this.p.setVec2(a.p);
       this.q.set(a.q);
     } else {
-      this.p.set(a);
+      this.p.setVec2(a);
       this.q.set(b);
     }
   }
@@ -209,7 +209,7 @@ export default class Transform {
     // = A.q' * B.q * v1 + A.q' * (B.p - A.p)
     const xf = Transform.identity();
     xf.q.set(Rot.mulTRot(a.q, b.q));
-    xf.p.set(Rot.mulTVec2(a.q, Vec2.sub(b.p, a.p)));
+    xf.p.setVec2(Rot.mulTVec2(a.q, Vec2.sub(b.p, a.p)));
     return xf;
   }
 }

--- a/src/common/Vec2.ts
+++ b/src/common/Vec2.ts
@@ -129,25 +129,30 @@ export default class Vec2 {
     return this;
   }
 
-  set(x: number, y: number): Vec2;
-  set(value: Vec2): Vec2;
   /**
    * Set this vector to some specified coordinates.
    *
    * @returns this
    */
-  // tslint:disable-next-line:typedef
-  set(x, y?) {
-    if (typeof x === 'object') {
-      _ASSERT && Vec2.assert(x);
-      this.x = x.x;
-      this.y = x.y;
-    } else {
-      _ASSERT && Math.assert(x);
-      _ASSERT && Math.assert(y);
-      this.x = x;
-      this.y = y;
-    }
+  set(x: number, y: number) {
+    _ASSERT && Math.assert(x);
+    _ASSERT && Math.assert(y);
+    this.x = x;
+    this.y = y;
+
+    return this;
+  }
+
+  /**
+   * Set this vector to some specified coordinates.
+   *
+   * @returns this
+   */
+  setVec2(value: Vec2) {
+    _ASSERT && Vec2.assert(value);
+    this.x = value.x;
+    this.y = value.y;
+
     return this;
   }
 
@@ -423,6 +428,35 @@ export default class Vec2 {
     }
   }
 
+  /**
+   * Perform the cross product on two vectors. In 2D this produces a scalar.
+   */
+  static crossVec2Vec2(v: Vec2, w: Vec2): number {
+    _ASSERT && Vec2.assert(v);
+    _ASSERT && Vec2.assert(w);
+    return v.x * w.y - v.y * w.x;
+  }
+
+  /**
+   * Perform the cross product on a vector and a scalar. In 2D this produces a
+   * vector.
+   */
+  static crossVec2Number(v: Vec2, w: number): Vec2 {
+    _ASSERT && Vec2.assert(v);
+    _ASSERT && Math.assert(w);
+    return Vec2.neo(w * v.y, -w * v.x);
+  }
+
+  /**
+   * Perform the cross product on a vector and a scalar. In 2D this produces a
+   * vector.
+   */
+  static crossNumberVec2(v: number, w: Vec2): Vec2 {
+    _ASSERT && Math.assert(v);
+    _ASSERT && Vec2.assert(w);
+    return Vec2.neo(-v * w.y, v * w.x);
+  }
+
   static addCross(a: Vec2, v: Vec2, w: number): Vec2;
   static addCross(a: Vec2, v: number, w: Vec2): Vec2;
   /**
@@ -444,6 +478,24 @@ export default class Vec2 {
     _ASSERT && common.assert(false);
   }
 
+  /**
+   * Returns `a + (v x w)`
+   */
+  static addCrossVec2Number(a: Vec2, v: Vec2, w: number): Vec2 {
+    _ASSERT && Vec2.assert(v);
+    _ASSERT && Math.assert(w);
+    return Vec2.neo(w * v.y + a.x, -w * v.x + a.y);
+  }
+
+  /**
+   * Returns `a + (v x w)`
+   */
+  static addCrossNumberVec2(a: Vec2, v: number, w: Vec2): Vec2 {
+    _ASSERT && Math.assert(v);
+    _ASSERT && Vec2.assert(w);
+    return Vec2.neo(-v * w.y + a.x, v * w.x + a.y);
+  }
+
   static add(v: Vec2, w: Vec2): Vec2 {
     _ASSERT && Vec2.assert(v);
     _ASSERT && Vec2.assert(w);
@@ -455,7 +507,7 @@ export default class Vec2 {
     if (typeof b !== 'undefined' || typeof w !== 'undefined') {
       return Vec2.combine(a, v, b, w);
     } else {
-      return Vec2.mul(a, v);
+      return Vec2.mulNumberVec2(a, v);
     }
   }
 
@@ -483,6 +535,18 @@ export default class Vec2 {
       _ASSERT && Vec2.assert(b);
       return Vec2.neo(a * b.x, a * b.y);
     }
+  }
+
+  static mulVec2Number(a: Vec2, b: number): Vec2 {
+    _ASSERT && Vec2.assert(a);
+    _ASSERT && Math.assert(b);
+    return Vec2.neo(a.x * b, a.y * b);
+  }
+
+  static mulNumberVec2(a: number, b: Vec2): Vec2 {
+    _ASSERT && Math.assert(a);
+    _ASSERT && Vec2.assert(b);
+    return Vec2.neo(a * b.x, a * b.y);
   }
 
   neg(): Vec2 {

--- a/src/common/Vec2.ts
+++ b/src/common/Vec2.ts
@@ -129,12 +129,34 @@ export default class Vec2 {
     return this;
   }
 
+  set(x: number, y: number): Vec2;
+  set(value: Vec2): Vec2;
   /**
    * Set this vector to some specified coordinates.
    *
    * @returns this
    */
-  set(x: number, y: number) {
+  // tslint:disable-next-line:typedef
+  set(x, y?) {
+    if (typeof x === 'object') {
+      _ASSERT && Vec2.assert(x);
+      this.x = x.x;
+      this.y = x.y;
+    } else {
+      _ASSERT && Math.assert(x);
+      _ASSERT && Math.assert(y);
+      this.x = x;
+      this.y = y;
+    }
+    return this;
+  }
+
+  /**
+   * Set this vector to some specified coordinates.
+   *
+   * @returns this
+   */
+   setNum(x: number, y: number) {
     _ASSERT && Math.assert(x);
     _ASSERT && Math.assert(y);
     this.x = x;

--- a/src/common/Vec2.ts
+++ b/src/common/Vec2.ts
@@ -441,7 +441,7 @@ export default class Vec2 {
    * Perform the cross product on a vector and a scalar. In 2D this produces a
    * vector.
    */
-  static crossVec2Number(v: Vec2, w: number): Vec2 {
+  static crossVec2Num(v: Vec2, w: number): Vec2 {
     _ASSERT && Vec2.assert(v);
     _ASSERT && Math.assert(w);
     return Vec2.neo(w * v.y, -w * v.x);
@@ -451,7 +451,7 @@ export default class Vec2 {
    * Perform the cross product on a vector and a scalar. In 2D this produces a
    * vector.
    */
-  static crossNumberVec2(v: number, w: Vec2): Vec2 {
+  static crossNumVec2(v: number, w: Vec2): Vec2 {
     _ASSERT && Math.assert(v);
     _ASSERT && Vec2.assert(w);
     return Vec2.neo(-v * w.y, v * w.x);
@@ -481,7 +481,7 @@ export default class Vec2 {
   /**
    * Returns `a + (v x w)`
    */
-  static addCrossVec2Number(a: Vec2, v: Vec2, w: number): Vec2 {
+  static addCrossVec2Num(a: Vec2, v: Vec2, w: number): Vec2 {
     _ASSERT && Vec2.assert(v);
     _ASSERT && Math.assert(w);
     return Vec2.neo(w * v.y + a.x, -w * v.x + a.y);
@@ -490,7 +490,7 @@ export default class Vec2 {
   /**
    * Returns `a + (v x w)`
    */
-  static addCrossNumberVec2(a: Vec2, v: number, w: Vec2): Vec2 {
+  static addCrossNumVec2(a: Vec2, v: number, w: Vec2): Vec2 {
     _ASSERT && Math.assert(v);
     _ASSERT && Vec2.assert(w);
     return Vec2.neo(-v * w.y + a.x, v * w.x + a.y);
@@ -507,7 +507,7 @@ export default class Vec2 {
     if (typeof b !== 'undefined' || typeof w !== 'undefined') {
       return Vec2.combine(a, v, b, w);
     } else {
-      return Vec2.mulNumberVec2(a, v);
+      return Vec2.mulNumVec2(a, v);
     }
   }
 
@@ -537,13 +537,13 @@ export default class Vec2 {
     }
   }
 
-  static mulVec2Number(a: Vec2, b: number): Vec2 {
+  static mulVec2Num(a: Vec2, b: number): Vec2 {
     _ASSERT && Vec2.assert(a);
     _ASSERT && Math.assert(b);
     return Vec2.neo(a.x * b, a.y * b);
   }
 
-  static mulNumberVec2(a: number, b: Vec2): Vec2 {
+  static mulNumVec2(a: number, b: Vec2): Vec2 {
     _ASSERT && Math.assert(a);
     _ASSERT && Vec2.assert(b);
     return Vec2.neo(a * b.x, a * b.y);

--- a/src/dynamics/Body.ts
+++ b/src/dynamics/Body.ts
@@ -573,7 +573,7 @@ export default class Body {
       return;
     }
 
-    this.m_xf.set(position, angle);
+    this.m_xf.setNum(position, angle);
     this.m_sweep.setTransform(this.m_xf);
 
     const broadPhase = this.m_world.m_broadPhase;

--- a/src/dynamics/Body.ts
+++ b/src/dynamics/Body.ts
@@ -663,7 +663,7 @@ export default class Body {
    */
   getLinearVelocityFromWorldPoint(worldPoint: Vec2): Vec2 {
     const localCenter = Vec2.sub(worldPoint, this.m_sweep.c);
-    return Vec2.add(this.m_linearVelocity, Vec2.crossNumberVec2(this.m_angularVelocity,
+    return Vec2.add(this.m_linearVelocity, Vec2.crossNumVec2(this.m_angularVelocity,
       localCenter));
   }
 
@@ -834,7 +834,7 @@ export default class Body {
     this.m_sweep.setLocalCenter(localCenter, this.m_xf);
 
     // Update center of mass velocity.
-    this.m_linearVelocity.add(Vec2.crossNumberVec2(this.m_angularVelocity, Vec2.sub(
+    this.m_linearVelocity.add(Vec2.crossNumVec2(this.m_angularVelocity, Vec2.sub(
       this.m_sweep.c, oldCenter)));
   }
 
@@ -879,7 +879,7 @@ export default class Body {
     this.m_sweep.setLocalCenter(massData.center, this.m_xf);
 
     // Update center of mass velocity.
-    this.m_linearVelocity.add(Vec2.crossNumberVec2(this.m_angularVelocity, Vec2.sub(
+    this.m_linearVelocity.add(Vec2.crossNumVec2(this.m_angularVelocity, Vec2.sub(
       this.m_sweep.c, oldCenter)));
   }
 

--- a/src/dynamics/Body.ts
+++ b/src/dynamics/Body.ts
@@ -606,7 +606,7 @@ export default class Body {
   advance(alpha: number): void {
     // Advance to the new safe time. This doesn't sync the broad-phase.
     this.m_sweep.advance(alpha);
-    this.m_sweep.c.set(this.m_sweep.c0);
+    this.m_sweep.c.setVec2(this.m_sweep.c0);
     this.m_sweep.a = this.m_sweep.a0;
     this.m_sweep.getTransform(this.m_xf, 1);
   }
@@ -663,7 +663,7 @@ export default class Body {
    */
   getLinearVelocityFromWorldPoint(worldPoint: Vec2): Vec2 {
     const localCenter = Vec2.sub(worldPoint, this.m_sweep.c);
-    return Vec2.add(this.m_linearVelocity, Vec2.cross(this.m_angularVelocity,
+    return Vec2.add(this.m_linearVelocity, Vec2.crossNumberVec2(this.m_angularVelocity,
       localCenter));
   }
 
@@ -688,7 +688,7 @@ export default class Body {
     if (Vec2.dot(v, v) > 0.0) {
       this.setAwake(true);
     }
-    this.m_linearVelocity.set(v);
+    this.m_linearVelocity.setVec2(v);
   }
 
   /**
@@ -767,7 +767,7 @@ export default class Body {
   getMassData(data: MassData): void {
     data.mass = this.m_mass;
     data.I = this.getInertia();
-    data.center.set(this.m_sweep.localCenter);
+    data.center.setVec2(this.m_sweep.localCenter);
   }
 
   /**
@@ -785,8 +785,8 @@ export default class Body {
 
     // Static and kinematic bodies have zero mass.
     if (this.isStatic() || this.isKinematic()) {
-      this.m_sweep.c0.set(this.m_xf.p);
-      this.m_sweep.c.set(this.m_xf.p);
+      this.m_sweep.c0.setVec2(this.m_xf.p);
+      this.m_sweep.c.setVec2(this.m_xf.p);
       this.m_sweep.a0 = this.m_sweep.a;
       return;
     }
@@ -834,7 +834,7 @@ export default class Body {
     this.m_sweep.setLocalCenter(localCenter, this.m_xf);
 
     // Update center of mass velocity.
-    this.m_linearVelocity.add(Vec2.cross(this.m_angularVelocity, Vec2.sub(
+    this.m_linearVelocity.add(Vec2.crossNumberVec2(this.m_angularVelocity, Vec2.sub(
       this.m_sweep.c, oldCenter)));
   }
 
@@ -879,7 +879,7 @@ export default class Body {
     this.m_sweep.setLocalCenter(massData.center, this.m_xf);
 
     // Update center of mass velocity.
-    this.m_linearVelocity.add(Vec2.cross(this.m_angularVelocity, Vec2.sub(
+    this.m_linearVelocity.add(Vec2.crossNumberVec2(this.m_angularVelocity, Vec2.sub(
       this.m_sweep.c, oldCenter)));
   }
 
@@ -902,7 +902,7 @@ export default class Body {
     // Don't accumulate a force if the body is sleeping.
     if (this.m_awakeFlag) {
       this.m_force.add(force);
-      this.m_torque += Vec2.cross(Vec2.sub(point, this.m_sweep.c), force);
+      this.m_torque += Vec2.crossVec2Vec2(Vec2.sub(point, this.m_sweep.c), force);
     }
   }
 
@@ -965,7 +965,7 @@ export default class Body {
     // Don't accumulate velocity if the body is sleeping
     if (this.m_awakeFlag) {
       this.m_linearVelocity.addMul(this.m_invMass, impulse);
-      this.m_angularVelocity += this.m_invI * Vec2.cross(Vec2.sub(point, this.m_sweep.c), impulse);
+      this.m_angularVelocity += this.m_invI * Vec2.crossVec2Vec2(Vec2.sub(point, this.m_sweep.c), impulse);
     }
   }
 

--- a/src/dynamics/Contact.ts
+++ b/src/dynamics/Contact.ts
@@ -636,7 +636,7 @@ export default class Contact {
       // Compute normal impulse
       const impulse = K > 0.0 ? -C / K : 0.0;
 
-      const P = Vec2.mulNumberVec2(impulse, normal);
+      const P = Vec2.mulNumVec2(impulse, normal);
 
       cA.subMul(mA, P);
       aA -= iA * Vec2.crossVec2Vec2(rA, P);
@@ -714,7 +714,7 @@ export default class Contact {
 
       vcp.normalMass = kNormal > 0.0 ? 1.0 / kNormal : 0.0;
 
-      const tangent = Vec2.crossVec2Number(this.v_normal, 1.0);
+      const tangent = Vec2.crossVec2Num(this.v_normal, 1.0);
 
       const rtA = Vec2.crossVec2Vec2(vcp.rA, tangent);
       const rtB = Vec2.crossVec2Vec2(vcp.rB, tangent);
@@ -726,9 +726,9 @@ export default class Contact {
       // Setup a velocity bias for restitution.
       vcp.velocityBias = 0.0;
       const vRel = Vec2.dot(this.v_normal, vB)
-        + Vec2.dot(this.v_normal, Vec2.crossNumberVec2(wB, vcp.rB))
+        + Vec2.dot(this.v_normal, Vec2.crossNumVec2(wB, vcp.rB))
         - Vec2.dot(this.v_normal, vA)
-        - Vec2.dot(this.v_normal, Vec2.crossNumberVec2(wA, vcp.rA));
+        - Vec2.dot(this.v_normal, Vec2.crossNumVec2(wA, vcp.rA));
       if (vRel < -Settings.velocityThreshold) {
         vcp.velocityBias = -this.v_restitution * vRel;
       }
@@ -796,7 +796,7 @@ export default class Contact {
     let wB = velocityB.w;
 
     const normal = this.v_normal;
-    const tangent = Vec2.crossVec2Number(normal, 1.0);
+    const tangent = Vec2.crossVec2Num(normal, 1.0);
 
     for (let j = 0; j < this.v_pointCount; ++j) {
       const vcp = this.v_points[j]; // VelocityConstraintPoint
@@ -843,7 +843,7 @@ export default class Contact {
     let wB = velocityB.w;
 
     const normal = this.v_normal;
-    const tangent = Vec2.crossVec2Number(normal, 1.0);
+    const tangent = Vec2.crossVec2Num(normal, 1.0);
     const friction = this.v_friction;
 
     _ASSERT && common.assert(this.v_pointCount == 1 || this.v_pointCount == 2);
@@ -855,8 +855,8 @@ export default class Contact {
 
       // Relative velocity at contact
       const dv = Vec2.zero();
-      dv.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, vcp.rB));
-      dv.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, vcp.rA));
+      dv.addCombine(1, vB, 1, Vec2.crossNumVec2(wB, vcp.rB));
+      dv.subCombine(1, vA, 1, Vec2.crossNumVec2(wA, vcp.rA));
 
       // Compute tangent force
       const vt = Vec2.dot(dv, tangent) - this.v_tangentSpeed;
@@ -869,7 +869,7 @@ export default class Contact {
       vcp.tangentImpulse = newImpulse;
 
       // Apply contact impulse
-      const P = Vec2.mulNumberVec2(lambda, tangent);
+      const P = Vec2.mulNumVec2(lambda, tangent);
 
       vA.subMul(mA, P);
       wA -= iA * Vec2.crossVec2Vec2(vcp.rA, P);
@@ -885,8 +885,8 @@ export default class Contact {
 
         // Relative velocity at contact
         const dv = Vec2.zero();
-        dv.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, vcp.rB));
-        dv.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, vcp.rA));
+        dv.addCombine(1, vB, 1, Vec2.crossNumVec2(wB, vcp.rB));
+        dv.subCombine(1, vA, 1, Vec2.crossNumVec2(wA, vcp.rA));
 
         // Compute normal impulse
         const vn = Vec2.dot(dv, normal);
@@ -898,7 +898,7 @@ export default class Contact {
         vcp.normalImpulse = newImpulse;
 
         // Apply contact impulse
-        const P = Vec2.mulNumberVec2(lambda, normal);
+        const P = Vec2.mulNumVec2(lambda, normal);
 
         vA.subMul(mA, P);
         wA -= iA * Vec2.crossVec2Vec2(vcp.rA, P);
@@ -955,8 +955,8 @@ export default class Contact {
       _ASSERT && common.assert(a.x >= 0.0 && a.y >= 0.0);
 
       // Relative velocity at contact
-      let dv1 = Vec2.zero().add(vB).add(Vec2.crossNumberVec2(wB, vcp1.rB)).sub(vA).sub(Vec2.crossNumberVec2(wA, vcp1.rA));
-      let dv2 = Vec2.zero().add(vB).add(Vec2.crossNumberVec2(wB, vcp2.rB)).sub(vA).sub(Vec2.crossNumberVec2(wA, vcp2.rA));
+      let dv1 = Vec2.zero().add(vB).add(Vec2.crossNumVec2(wB, vcp1.rB)).sub(vA).sub(Vec2.crossNumVec2(wA, vcp1.rA));
+      let dv2 = Vec2.zero().add(vB).add(Vec2.crossNumVec2(wB, vcp2.rB)).sub(vA).sub(Vec2.crossNumVec2(wA, vcp2.rA));
 
       // Compute normal velocity
       let vn1 = Vec2.dot(dv1, normal);
@@ -987,8 +987,8 @@ export default class Contact {
           const d = Vec2.sub(x, a);
 
           // Apply incremental impulse
-          const P1 = Vec2.mulNumberVec2(d.x, normal);
-          const P2 = Vec2.mulNumberVec2(d.y, normal);
+          const P1 = Vec2.mulNumVec2(d.x, normal);
+          const P2 = Vec2.mulNumVec2(d.y, normal);
 
           vA.subCombine(mA, P1, mA, P2);
           wA -= iA * (Vec2.crossVec2Vec2(vcp1.rA, P1) + Vec2.crossVec2Vec2(vcp2.rA, P2));
@@ -1002,8 +1002,8 @@ export default class Contact {
 
           if (DEBUG_SOLVER) {
             // Postconditions
-            dv1 = Vec2.sub(Vec2.add(vB, Vec2.crossNumberVec2(wB, vcp1.rB)), Vec2.add(vA, Vec2.crossNumberVec2(wA, vcp1.rA)));
-            dv2 = Vec2.sub(Vec2.add(vB, Vec2.crossNumberVec2(wB, vcp2.rB)), Vec2.add(vA, Vec2.crossNumberVec2(wA, vcp2.rA)));
+            dv1 = Vec2.sub(Vec2.add(vB, Vec2.crossNumVec2(wB, vcp1.rB)), Vec2.add(vA, Vec2.crossNumVec2(wA, vcp1.rA)));
+            dv2 = Vec2.sub(Vec2.add(vB, Vec2.crossNumVec2(wB, vcp2.rB)), Vec2.add(vA, Vec2.crossNumVec2(wA, vcp2.rA)));
 
             // Compute normal velocity
             vn1 = Vec2.dot(dv1, normal);
@@ -1031,8 +1031,8 @@ export default class Contact {
           const d = Vec2.sub(x, a);
 
           // Apply incremental impulse
-          const P1 = Vec2.mulNumberVec2(d.x, normal);
-          const P2 = Vec2.mulNumberVec2(d.y, normal);
+          const P1 = Vec2.mulNumVec2(d.x, normal);
+          const P2 = Vec2.mulNumVec2(d.y, normal);
           vA.subCombine(mA, P1, mA, P2);
           wA -= iA * (Vec2.crossVec2Vec2(vcp1.rA, P1) + Vec2.crossVec2Vec2(vcp2.rA, P2));
 
@@ -1045,8 +1045,8 @@ export default class Contact {
 
           if (DEBUG_SOLVER) {
             // Postconditions
-            const dv1B = Vec2.add(vB, Vec2.crossNumberVec2(wB, vcp1.rB));
-            const dv1A = Vec2.add(vA, Vec2.crossNumberVec2(wA, vcp1.rA));
+            const dv1B = Vec2.add(vB, Vec2.crossNumVec2(wB, vcp1.rB));
+            const dv1A = Vec2.add(vA, Vec2.crossNumVec2(wA, vcp1.rA));
             const dv1 = Vec2.sub(dv1B, dv1A);
 
             // Compute normal velocity
@@ -1073,8 +1073,8 @@ export default class Contact {
           const d = Vec2.sub(x, a);
 
           // Apply incremental impulse
-          const P1 = Vec2.mulNumberVec2(d.x, normal);
-          const P2 = Vec2.mulNumberVec2(d.y, normal);
+          const P1 = Vec2.mulNumVec2(d.x, normal);
+          const P2 = Vec2.mulNumVec2(d.y, normal);
           vA.subCombine(mA, P1, mA, P2);
           wA -= iA * (Vec2.crossVec2Vec2(vcp1.rA, P1) + Vec2.crossVec2Vec2(vcp2.rA, P2));
 
@@ -1087,8 +1087,8 @@ export default class Contact {
 
           if (DEBUG_SOLVER) {
             // Postconditions
-            const dv2B = Vec2.add(vB, Vec2.crossNumberVec2(wB, vcp2.rB));
-            const dv2A = Vec2.add(vA, Vec2.crossNumberVec2(wA, vcp2.rA));
+            const dv2B = Vec2.add(vB, Vec2.crossNumVec2(wB, vcp2.rB));
+            const dv2A = Vec2.add(vA, Vec2.crossNumVec2(wA, vcp2.rA));
             const dv1 = Vec2.sub(dv2B, dv2A);
 
             // Compute normal velocity
@@ -1115,8 +1115,8 @@ export default class Contact {
           const d = Vec2.sub(x, a);
 
           // Apply incremental impulse
-          const P1 = Vec2.mulNumberVec2(d.x, normal);
-          const P2 = Vec2.mulNumberVec2(d.y, normal);
+          const P1 = Vec2.mulNumVec2(d.x, normal);
+          const P2 = Vec2.mulNumVec2(d.y, normal);
           vA.subCombine(mA, P1, mA, P2);
           wA -= iA * (Vec2.crossVec2Vec2(vcp1.rA, P1) + Vec2.crossVec2Vec2(vcp2.rA, P2));
 

--- a/src/dynamics/Contact.ts
+++ b/src/dynamics/Contact.ts
@@ -573,8 +573,8 @@ export default class Contact {
     for (let j = 0; j < this.p_pointCount; ++j) {
       const xfA = Transform.identity();
       const xfB = Transform.identity();
-      xfA.q.set(aA);
-      xfB.q.set(aB);
+      xfA.q.setAngle(aA);
+      xfB.q.setAngle(aB);
       xfA.p = Vec2.sub(cA, Rot.mulVec2(xfA.q, localCenterA));
       xfB.p = Vec2.sub(cB, Rot.mulVec2(xfB.q, localCenterB));
 
@@ -692,8 +692,8 @@ export default class Contact {
 
     const xfA = Transform.identity();
     const xfB = Transform.identity();
-    xfA.q.set(aA);
-    xfB.q.set(aB);
+    xfA.q.setAngle(aA);
+    xfB.q.setAngle(aB);
     xfA.p.setCombine(1, cA, -1, Rot.mulVec2(xfA.q, localCenterA));
     xfB.p.setCombine(1, cB, -1, Rot.mulVec2(xfB.q, localCenterB));
 

--- a/src/dynamics/Contact.ts
+++ b/src/dynamics/Contact.ts
@@ -752,8 +752,8 @@ export default class Contact {
       const k_maxConditionNumber = 1000.0;
       if (k11 * k11 < k_maxConditionNumber * (k11 * k22 - k12 * k12)) {
         // K is safe to invert.
-        this.v_K.ex.set(k11, k12);
-        this.v_K.ey.set(k12, k22);
+        this.v_K.ex.setNum(k11, k12);
+        this.v_K.ey.setNum(k12, k22);
         this.v_normalMass.set(this.v_K.getInverse());
       } else {
         // The constraints are redundant, just use one.

--- a/src/dynamics/Contact.ts
+++ b/src/dynamics/Contact.ts
@@ -629,26 +629,26 @@ export default class Contact {
       const C = Math.clamp(baumgarte * (separation + linearSlop), -maxLinearCorrection, 0.0);
 
       // Compute the effective mass.
-      const rnA = Vec2.cross(rA, normal);
-      const rnB = Vec2.cross(rB, normal);
+      const rnA = Vec2.crossVec2Vec2(rA, normal);
+      const rnB = Vec2.crossVec2Vec2(rB, normal);
       const K = mA + mB + iA * rnA * rnA + iB * rnB * rnB;
 
       // Compute normal impulse
       const impulse = K > 0.0 ? -C / K : 0.0;
 
-      const P = Vec2.mul(impulse, normal);
+      const P = Vec2.mulNumberVec2(impulse, normal);
 
       cA.subMul(mA, P);
-      aA -= iA * Vec2.cross(rA, P);
+      aA -= iA * Vec2.crossVec2Vec2(rA, P);
 
       cB.addMul(mB, P);
-      aB += iB * Vec2.cross(rB, P);
+      aB += iB * Vec2.crossVec2Vec2(rB, P);
     }
 
-    positionA.c.set(cA);
+    positionA.c.setVec2(cA);
     positionA.a = aA;
 
-    positionB.c.set(cB);
+    positionB.c.setVec2(cB);
     positionB.a = aB;
 
     return minSeparation;
@@ -699,25 +699,25 @@ export default class Contact {
 
     const worldManifold = manifold.getWorldManifold(null, xfA, radiusA, xfB, radiusB);
 
-    this.v_normal.set(worldManifold.normal);
+    this.v_normal.setVec2(worldManifold.normal);
 
     for (let j = 0; j < this.v_pointCount; ++j) {
       const vcp = this.v_points[j]; // VelocityConstraintPoint
 
-      vcp.rA.set(Vec2.sub(worldManifold.points[j], cA));
-      vcp.rB.set(Vec2.sub(worldManifold.points[j], cB));
+      vcp.rA.setVec2(Vec2.sub(worldManifold.points[j], cA));
+      vcp.rB.setVec2(Vec2.sub(worldManifold.points[j], cB));
 
-      const rnA = Vec2.cross(vcp.rA, this.v_normal);
-      const rnB = Vec2.cross(vcp.rB, this.v_normal);
+      const rnA = Vec2.crossVec2Vec2(vcp.rA, this.v_normal);
+      const rnB = Vec2.crossVec2Vec2(vcp.rB, this.v_normal);
 
       const kNormal = mA + mB + iA * rnA * rnA + iB * rnB * rnB;
 
       vcp.normalMass = kNormal > 0.0 ? 1.0 / kNormal : 0.0;
 
-      const tangent = Vec2.cross(this.v_normal, 1.0);
+      const tangent = Vec2.crossVec2Number(this.v_normal, 1.0);
 
-      const rtA = Vec2.cross(vcp.rA, tangent);
-      const rtB = Vec2.cross(vcp.rB, tangent);
+      const rtA = Vec2.crossVec2Vec2(vcp.rA, tangent);
+      const rtB = Vec2.crossVec2Vec2(vcp.rB, tangent);
 
       const kTangent = mA + mB + iA * rtA * rtA + iB * rtB * rtB;
 
@@ -726,9 +726,9 @@ export default class Contact {
       // Setup a velocity bias for restitution.
       vcp.velocityBias = 0.0;
       const vRel = Vec2.dot(this.v_normal, vB)
-        + Vec2.dot(this.v_normal, Vec2.cross(wB, vcp.rB))
+        + Vec2.dot(this.v_normal, Vec2.crossNumberVec2(wB, vcp.rB))
         - Vec2.dot(this.v_normal, vA)
-        - Vec2.dot(this.v_normal, Vec2.cross(wA, vcp.rA));
+        - Vec2.dot(this.v_normal, Vec2.crossNumberVec2(wA, vcp.rA));
       if (vRel < -Settings.velocityThreshold) {
         vcp.velocityBias = -this.v_restitution * vRel;
       }
@@ -739,10 +739,10 @@ export default class Contact {
       const vcp1 = this.v_points[0]; // VelocityConstraintPoint
       const vcp2 = this.v_points[1]; // VelocityConstraintPoint
 
-      const rn1A = Vec2.cross(vcp1.rA, this.v_normal);
-      const rn1B = Vec2.cross(vcp1.rB, this.v_normal);
-      const rn2A = Vec2.cross(vcp2.rA, this.v_normal);
-      const rn2B = Vec2.cross(vcp2.rB, this.v_normal);
+      const rn1A = Vec2.crossVec2Vec2(vcp1.rA, this.v_normal);
+      const rn1B = Vec2.crossVec2Vec2(vcp1.rB, this.v_normal);
+      const rn2A = Vec2.crossVec2Vec2(vcp2.rA, this.v_normal);
+      const rn2B = Vec2.crossVec2Vec2(vcp2.rB, this.v_normal);
 
       const k11 = mA + mB + iA * rn1A * rn1A + iB * rn1B * rn1B;
       const k22 = mA + mB + iA * rn2A * rn2A + iB * rn2B * rn2B;
@@ -762,14 +762,14 @@ export default class Contact {
       }
     }
 
-    positionA.c.set(cA);
+    positionA.c.setVec2(cA);
     positionA.a = aA;
-    velocityA.v.set(vA);
+    velocityA.v.setVec2(vA);
     velocityA.w = wA;
 
-    positionB.c.set(cB);
+    positionB.c.setVec2(cB);
     positionB.a = aB;
-    velocityB.v.set(vB);
+    velocityB.v.setVec2(vB);
     velocityB.w = wB;
   }
 
@@ -796,21 +796,21 @@ export default class Contact {
     let wB = velocityB.w;
 
     const normal = this.v_normal;
-    const tangent = Vec2.cross(normal, 1.0);
+    const tangent = Vec2.crossVec2Number(normal, 1.0);
 
     for (let j = 0; j < this.v_pointCount; ++j) {
       const vcp = this.v_points[j]; // VelocityConstraintPoint
 
       const P = Vec2.combine(vcp.normalImpulse, normal, vcp.tangentImpulse, tangent);
-      wA -= iA * Vec2.cross(vcp.rA, P);
+      wA -= iA * Vec2.crossVec2Vec2(vcp.rA, P);
       vA.subMul(mA, P);
-      wB += iB * Vec2.cross(vcp.rB, P);
+      wB += iB * Vec2.crossVec2Vec2(vcp.rB, P);
       vB.addMul(mB, P);
     }
 
-    velocityA.v.set(vA);
+    velocityA.v.setVec2(vA);
     velocityA.w = wA;
-    velocityB.v.set(vB);
+    velocityB.v.setVec2(vB);
     velocityB.w = wB;
   }
 
@@ -843,7 +843,7 @@ export default class Contact {
     let wB = velocityB.w;
 
     const normal = this.v_normal;
-    const tangent = Vec2.cross(normal, 1.0);
+    const tangent = Vec2.crossVec2Number(normal, 1.0);
     const friction = this.v_friction;
 
     _ASSERT && common.assert(this.v_pointCount == 1 || this.v_pointCount == 2);
@@ -855,8 +855,8 @@ export default class Contact {
 
       // Relative velocity at contact
       const dv = Vec2.zero();
-      dv.addCombine(1, vB, 1, Vec2.cross(wB, vcp.rB));
-      dv.subCombine(1, vA, 1, Vec2.cross(wA, vcp.rA));
+      dv.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, vcp.rB));
+      dv.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, vcp.rA));
 
       // Compute tangent force
       const vt = Vec2.dot(dv, tangent) - this.v_tangentSpeed;
@@ -869,13 +869,13 @@ export default class Contact {
       vcp.tangentImpulse = newImpulse;
 
       // Apply contact impulse
-      const P = Vec2.mul(lambda, tangent);
+      const P = Vec2.mulNumberVec2(lambda, tangent);
 
       vA.subMul(mA, P);
-      wA -= iA * Vec2.cross(vcp.rA, P);
+      wA -= iA * Vec2.crossVec2Vec2(vcp.rA, P);
 
       vB.addMul(mB, P);
-      wB += iB * Vec2.cross(vcp.rB, P);
+      wB += iB * Vec2.crossVec2Vec2(vcp.rB, P);
     }
 
     // Solve normal constraints
@@ -885,8 +885,8 @@ export default class Contact {
 
         // Relative velocity at contact
         const dv = Vec2.zero();
-        dv.addCombine(1, vB, 1, Vec2.cross(wB, vcp.rB));
-        dv.subCombine(1, vA, 1, Vec2.cross(wA, vcp.rA));
+        dv.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, vcp.rB));
+        dv.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, vcp.rA));
 
         // Compute normal impulse
         const vn = Vec2.dot(dv, normal);
@@ -898,13 +898,13 @@ export default class Contact {
         vcp.normalImpulse = newImpulse;
 
         // Apply contact impulse
-        const P = Vec2.mul(lambda, normal);
+        const P = Vec2.mulNumberVec2(lambda, normal);
 
         vA.subMul(mA, P);
-        wA -= iA * Vec2.cross(vcp.rA, P);
+        wA -= iA * Vec2.crossVec2Vec2(vcp.rA, P);
 
         vB.addMul(mB, P);
-        wB += iB * Vec2.cross(vcp.rB, P);
+        wB += iB * Vec2.crossVec2Vec2(vcp.rB, P);
       }
     } else {
       // Block solver developed in collaboration with Dirk Gregorius (back in
@@ -955,8 +955,8 @@ export default class Contact {
       _ASSERT && common.assert(a.x >= 0.0 && a.y >= 0.0);
 
       // Relative velocity at contact
-      let dv1 = Vec2.zero().add(vB).add(Vec2.cross(wB, vcp1.rB)).sub(vA).sub(Vec2.cross(wA, vcp1.rA));
-      let dv2 = Vec2.zero().add(vB).add(Vec2.cross(wB, vcp2.rB)).sub(vA).sub(Vec2.cross(wA, vcp2.rA));
+      let dv1 = Vec2.zero().add(vB).add(Vec2.crossNumberVec2(wB, vcp1.rB)).sub(vA).sub(Vec2.crossNumberVec2(wA, vcp1.rA));
+      let dv2 = Vec2.zero().add(vB).add(Vec2.crossNumberVec2(wB, vcp2.rB)).sub(vA).sub(Vec2.crossNumberVec2(wA, vcp2.rA));
 
       // Compute normal velocity
       let vn1 = Vec2.dot(dv1, normal);
@@ -987,14 +987,14 @@ export default class Contact {
           const d = Vec2.sub(x, a);
 
           // Apply incremental impulse
-          const P1 = Vec2.mul(d.x, normal);
-          const P2 = Vec2.mul(d.y, normal);
+          const P1 = Vec2.mulNumberVec2(d.x, normal);
+          const P2 = Vec2.mulNumberVec2(d.y, normal);
 
           vA.subCombine(mA, P1, mA, P2);
-          wA -= iA * (Vec2.cross(vcp1.rA, P1) + Vec2.cross(vcp2.rA, P2));
+          wA -= iA * (Vec2.crossVec2Vec2(vcp1.rA, P1) + Vec2.crossVec2Vec2(vcp2.rA, P2));
 
           vB.addCombine(mB, P1, mB, P2);
-          wB += iB * (Vec2.cross(vcp1.rB, P1) + Vec2.cross(vcp2.rB, P2));
+          wB += iB * (Vec2.crossVec2Vec2(vcp1.rB, P1) + Vec2.crossVec2Vec2(vcp2.rB, P2));
 
           // Accumulate
           vcp1.normalImpulse = x.x;
@@ -1002,8 +1002,8 @@ export default class Contact {
 
           if (DEBUG_SOLVER) {
             // Postconditions
-            dv1 = Vec2.sub(Vec2.add(vB, Vec2.cross(wB, vcp1.rB)), Vec2.add(vA, Vec2.cross(wA, vcp1.rA)));
-            dv2 = Vec2.sub(Vec2.add(vB, Vec2.cross(wB, vcp2.rB)), Vec2.add(vA, Vec2.cross(wA, vcp2.rA)));
+            dv1 = Vec2.sub(Vec2.add(vB, Vec2.crossNumberVec2(wB, vcp1.rB)), Vec2.add(vA, Vec2.crossNumberVec2(wA, vcp1.rA)));
+            dv2 = Vec2.sub(Vec2.add(vB, Vec2.crossNumberVec2(wB, vcp2.rB)), Vec2.add(vA, Vec2.crossNumberVec2(wA, vcp2.rA)));
 
             // Compute normal velocity
             vn1 = Vec2.dot(dv1, normal);
@@ -1031,13 +1031,13 @@ export default class Contact {
           const d = Vec2.sub(x, a);
 
           // Apply incremental impulse
-          const P1 = Vec2.mul(d.x, normal);
-          const P2 = Vec2.mul(d.y, normal);
+          const P1 = Vec2.mulNumberVec2(d.x, normal);
+          const P2 = Vec2.mulNumberVec2(d.y, normal);
           vA.subCombine(mA, P1, mA, P2);
-          wA -= iA * (Vec2.cross(vcp1.rA, P1) + Vec2.cross(vcp2.rA, P2));
+          wA -= iA * (Vec2.crossVec2Vec2(vcp1.rA, P1) + Vec2.crossVec2Vec2(vcp2.rA, P2));
 
           vB.addCombine(mB, P1, mB, P2);
-          wB += iB * (Vec2.cross(vcp1.rB, P1) + Vec2.cross(vcp2.rB, P2));
+          wB += iB * (Vec2.crossVec2Vec2(vcp1.rB, P1) + Vec2.crossVec2Vec2(vcp2.rB, P2));
 
           // Accumulate
           vcp1.normalImpulse = x.x;
@@ -1045,8 +1045,8 @@ export default class Contact {
 
           if (DEBUG_SOLVER) {
             // Postconditions
-            const dv1B = Vec2.add(vB, Vec2.cross(wB, vcp1.rB));
-            const dv1A = Vec2.add(vA, Vec2.cross(wA, vcp1.rA));
+            const dv1B = Vec2.add(vB, Vec2.crossNumberVec2(wB, vcp1.rB));
+            const dv1A = Vec2.add(vA, Vec2.crossNumberVec2(wA, vcp1.rA));
             const dv1 = Vec2.sub(dv1B, dv1A);
 
             // Compute normal velocity
@@ -1073,13 +1073,13 @@ export default class Contact {
           const d = Vec2.sub(x, a);
 
           // Apply incremental impulse
-          const P1 = Vec2.mul(d.x, normal);
-          const P2 = Vec2.mul(d.y, normal);
+          const P1 = Vec2.mulNumberVec2(d.x, normal);
+          const P2 = Vec2.mulNumberVec2(d.y, normal);
           vA.subCombine(mA, P1, mA, P2);
-          wA -= iA * (Vec2.cross(vcp1.rA, P1) + Vec2.cross(vcp2.rA, P2));
+          wA -= iA * (Vec2.crossVec2Vec2(vcp1.rA, P1) + Vec2.crossVec2Vec2(vcp2.rA, P2));
 
           vB.addCombine(mB, P1, mB, P2);
-          wB += iB * (Vec2.cross(vcp1.rB, P1) + Vec2.cross(vcp2.rB, P2));
+          wB += iB * (Vec2.crossVec2Vec2(vcp1.rB, P1) + Vec2.crossVec2Vec2(vcp2.rB, P2));
 
           // Accumulate
           vcp1.normalImpulse = x.x;
@@ -1087,8 +1087,8 @@ export default class Contact {
 
           if (DEBUG_SOLVER) {
             // Postconditions
-            const dv2B = Vec2.add(vB, Vec2.cross(wB, vcp2.rB));
-            const dv2A = Vec2.add(vA, Vec2.cross(wA, vcp2.rA));
+            const dv2B = Vec2.add(vB, Vec2.crossNumberVec2(wB, vcp2.rB));
+            const dv2A = Vec2.add(vA, Vec2.crossNumberVec2(wA, vcp2.rA));
             const dv1 = Vec2.sub(dv2B, dv2A);
 
             // Compute normal velocity
@@ -1115,13 +1115,13 @@ export default class Contact {
           const d = Vec2.sub(x, a);
 
           // Apply incremental impulse
-          const P1 = Vec2.mul(d.x, normal);
-          const P2 = Vec2.mul(d.y, normal);
+          const P1 = Vec2.mulNumberVec2(d.x, normal);
+          const P2 = Vec2.mulNumberVec2(d.y, normal);
           vA.subCombine(mA, P1, mA, P2);
-          wA -= iA * (Vec2.cross(vcp1.rA, P1) + Vec2.cross(vcp2.rA, P2));
+          wA -= iA * (Vec2.crossVec2Vec2(vcp1.rA, P1) + Vec2.crossVec2Vec2(vcp2.rA, P2));
 
           vB.addCombine(mB, P1, mB, P2);
-          wB += iB * (Vec2.cross(vcp1.rB, P1) + Vec2.cross(vcp2.rB, P2));
+          wB += iB * (Vec2.crossVec2Vec2(vcp1.rB, P1) + Vec2.crossVec2Vec2(vcp2.rB, P2));
 
           // Accumulate
           vcp1.normalImpulse = x.x;
@@ -1136,10 +1136,10 @@ export default class Contact {
       }
     }
 
-    velocityA.v.set(vA);
+    velocityA.v.setVec2(vA);
     velocityA.w = wA;
 
-    velocityB.v.set(vB);
+    velocityB.v.setVec2(vB);
     velocityB.w = wB;
   }
 

--- a/src/dynamics/Position.ts
+++ b/src/dynamics/Position.ts
@@ -40,7 +40,7 @@ export default class Position {
   }
 
   getTransform(xf: Transform, p: Vec2): Transform {
-    xf.q.set(this.a);
+    xf.q.setAngle(this.a);
     xf.p.setVec2(Vec2.sub(this.c, Rot.mulVec2(xf.q, p)));
     return xf;
   }

--- a/src/dynamics/Position.ts
+++ b/src/dynamics/Position.ts
@@ -41,7 +41,7 @@ export default class Position {
 
   getTransform(xf: Transform, p: Vec2): Transform {
     xf.q.set(this.a);
-    xf.p.set(Vec2.sub(this.c, Rot.mulVec2(xf.q, p)));
+    xf.p.setVec2(Vec2.sub(this.c, Rot.mulVec2(xf.q, p)));
     return xf;
   }
 }

--- a/src/dynamics/Solver.ts
+++ b/src/dynamics/Solver.ts
@@ -392,7 +392,7 @@ export default class Solver {
       let w = body.c_velocity.w;
 
       // Check for large velocities
-      const translation = Vec2.mulNumberVec2(h, v);
+      const translation = Vec2.mulNumVec2(h, v);
       if (Vec2.lengthSquared(translation) > Settings.maxTranslationSquared) {
         const ratio = Settings.maxTranslation / translation.length();
         v.mul(ratio);
@@ -878,7 +878,7 @@ export default class Solver {
       let w = body.c_velocity.w;
 
       // Check for large velocities
-      const translation = Vec2.mulNumberVec2(h, v);
+      const translation = Vec2.mulNumVec2(h, v);
       if (Vec2.dot(translation, translation) > Settings.maxTranslationSquared) {
         const ratio = Settings.maxTranslation / translation.length();
         v.mul(ratio);

--- a/src/dynamics/Solver.ts
+++ b/src/dynamics/Solver.ts
@@ -299,7 +299,7 @@ export default class Solver {
       let w = body.m_angularVelocity;
 
       // Store positions for continuous collision.
-      body.m_sweep.c0.set(body.m_sweep.c);
+      body.m_sweep.c0.setVec2(body.m_sweep.c);
       body.m_sweep.a0 = body.m_sweep.a;
 
       if (body.isDynamic()) {
@@ -392,7 +392,7 @@ export default class Solver {
       let w = body.c_velocity.w;
 
       // Check for large velocities
-      const translation = Vec2.mul(h, v);
+      const translation = Vec2.mulNumberVec2(h, v);
       if (Vec2.lengthSquared(translation) > Settings.maxTranslationSquared) {
         const ratio = Settings.maxTranslation / translation.length();
         v.mul(ratio);
@@ -408,9 +408,9 @@ export default class Solver {
       c.addMul(h, v);
       a += h * w;
 
-      body.c_position.c.set(c);
+      body.c_position.c.setVec2(c);
       body.c_position.a = a;
-      body.c_velocity.v.set(v);
+      body.c_velocity.v.setVec2(v);
       body.c_velocity.w = w;
     }
 
@@ -449,9 +449,9 @@ export default class Solver {
     for (let i = 0; i < this.m_bodies.length; ++i) {
       const body = this.m_bodies[i];
 
-      body.m_sweep.c.set(body.c_position.c);
+      body.m_sweep.c.setVec2(body.c_position.c);
       body.m_sweep.a = body.c_position.a;
-      body.m_linearVelocity.set(body.c_velocity.v);
+      body.m_linearVelocity.setVec2(body.c_velocity.v);
       body.m_angularVelocity = body.c_velocity.w;
       body.synchronizeTransform();
     }
@@ -785,9 +785,9 @@ export default class Solver {
     // Initialize the body state.
     for (let i = 0; i < this.m_bodies.length; ++i) {
       const body = this.m_bodies[i];
-      body.c_position.c.set(body.m_sweep.c);
+      body.c_position.c.setVec2(body.m_sweep.c);
       body.c_position.a = body.m_sweep.a;
-      body.c_velocity.v.set(body.m_linearVelocity);
+      body.c_velocity.v.setVec2(body.m_linearVelocity);
       body.c_velocity.w = body.m_angularVelocity;
     }
 
@@ -843,9 +843,9 @@ export default class Solver {
     }
 
     // Leap of faith to new safe state.
-    toiA.m_sweep.c0.set(toiA.c_position.c);
+    toiA.m_sweep.c0.setVec2(toiA.c_position.c);
     toiA.m_sweep.a0 = toiA.c_position.a;
-    toiB.m_sweep.c0.set(toiB.c_position.c);
+    toiB.m_sweep.c0.setVec2(toiB.c_position.c);
     toiB.m_sweep.a0 = toiB.c_position.a;
 
     // No warm starting is needed for TOI events because warm
@@ -878,7 +878,7 @@ export default class Solver {
       let w = body.c_velocity.w;
 
       // Check for large velocities
-      const translation = Vec2.mul(h, v);
+      const translation = Vec2.mulNumberVec2(h, v);
       if (Vec2.dot(translation, translation) > Settings.maxTranslationSquared) {
         const ratio = Settings.maxTranslation / translation.length();
         v.mul(ratio);

--- a/src/dynamics/World.ts
+++ b/src/dynamics/World.ts
@@ -410,7 +410,7 @@ export default class World {
       const hit = fixture.rayCast(output, input, index);
       if (hit) {
         const fraction = output.fraction;
-        const point = Vec2.add(Vec2.mulNumberVec2((1.0 - fraction), input.p1), Vec2.mulNumberVec2(fraction, input.p2));
+        const point = Vec2.add(Vec2.mulNumVec2((1.0 - fraction), input.p1), Vec2.mulNumVec2(fraction, input.p2));
         return callback(fixture, point, output.normal, fraction);
       }
       return input.maxFraction;

--- a/src/dynamics/World.ts
+++ b/src/dynamics/World.ts
@@ -410,7 +410,7 @@ export default class World {
       const hit = fixture.rayCast(output, input, index);
       if (hit) {
         const fraction = output.fraction;
-        const point = Vec2.add(Vec2.mul((1.0 - fraction), input.p1), Vec2.mul(fraction, input.p2));
+        const point = Vec2.add(Vec2.mulNumberVec2((1.0 - fraction), input.p1), Vec2.mulNumberVec2(fraction, input.p2));
         return callback(fixture, point, output.normal, fraction);
       }
       return input.maxFraction;

--- a/src/dynamics/joint/DistanceJoint.ts
+++ b/src/dynamics/joint/DistanceJoint.ts
@@ -195,15 +195,15 @@ export default class DistanceJoint extends Joint {
     length?: number,
   }): void {
     if (def.anchorA) {
-      this.m_localAnchorA.set(this.m_bodyA.getLocalPoint(def.anchorA));
+      this.m_localAnchorA.setVec2(this.m_bodyA.getLocalPoint(def.anchorA));
     } else if (def.localAnchorA) {
-      this.m_localAnchorA.set(def.localAnchorA);
+      this.m_localAnchorA.setVec2(def.localAnchorA);
     }
 
     if (def.anchorB) {
-      this.m_localAnchorB.set(this.m_bodyB.getLocalPoint(def.anchorB));
+      this.m_localAnchorB.setVec2(this.m_bodyB.getLocalPoint(def.anchorB));
     } else if (def.localAnchorB) {
-      this.m_localAnchorB.set(def.localAnchorB);
+      this.m_localAnchorB.setVec2(def.localAnchorB);
     }
 
     if (def.length > 0) {
@@ -280,7 +280,7 @@ export default class DistanceJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mul(this.m_impulse, this.m_u).mul(inv_dt);
+    return Vec2.mulNumberVec2(this.m_impulse, this.m_u).mul(inv_dt);
   }
 
   /**
@@ -323,8 +323,8 @@ export default class DistanceJoint extends Joint {
       this.m_u.set(0.0, 0.0);
     }
 
-    const crAu = Vec2.cross(this.m_rA, this.m_u);
-    const crBu = Vec2.cross(this.m_rB, this.m_u);
+    const crAu = Vec2.crossVec2Vec2(this.m_rA, this.m_u);
+    const crBu = Vec2.crossVec2Vec2(this.m_rB, this.m_u);
     let invMass = this.m_invMassA + this.m_invIA * crAu * crAu + this.m_invMassB
         + this.m_invIB * crBu * crBu;
 
@@ -360,21 +360,21 @@ export default class DistanceJoint extends Joint {
       // Scale the impulse to support a variable time step.
       this.m_impulse *= step.dtRatio;
 
-      const P = Vec2.mul(this.m_impulse, this.m_u);
+      const P = Vec2.mulNumberVec2(this.m_impulse, this.m_u);
 
       vA.subMul(this.m_invMassA, P);
-      wA -= this.m_invIA * Vec2.cross(this.m_rA, P);
+      wA -= this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, P);
 
       vB.addMul(this.m_invMassB, P);
-      wB += this.m_invIB * Vec2.cross(this.m_rB, P);
+      wB += this.m_invIB * Vec2.crossVec2Vec2(this.m_rB, P);
 
     } else {
       this.m_impulse = 0.0;
     }
 
-    this.m_bodyA.c_velocity.v.set(vA);
+    this.m_bodyA.c_velocity.v.setVec2(vA);
     this.m_bodyA.c_velocity.w = wA;
-    this.m_bodyB.c_velocity.v.set(vB);
+    this.m_bodyB.c_velocity.v.setVec2(vB);
     this.m_bodyB.c_velocity.w = wB;
   }
 
@@ -385,23 +385,23 @@ export default class DistanceJoint extends Joint {
     let wB = this.m_bodyB.c_velocity.w;
 
     // Cdot = dot(u, v + cross(w, r))
-    const vpA = Vec2.add(vA, Vec2.cross(wA, this.m_rA));
-    const vpB = Vec2.add(vB, Vec2.cross(wB, this.m_rB));
+    const vpA = Vec2.add(vA, Vec2.crossNumberVec2(wA, this.m_rA));
+    const vpB = Vec2.add(vB, Vec2.crossNumberVec2(wB, this.m_rB));
     const Cdot = Vec2.dot(this.m_u, vpB) - Vec2.dot(this.m_u, vpA);
 
     const impulse = -this.m_mass
         * (Cdot + this.m_bias + this.m_gamma * this.m_impulse);
     this.m_impulse += impulse;
 
-    const P = Vec2.mul(impulse, this.m_u);
+    const P = Vec2.mulNumberVec2(impulse, this.m_u);
     vA.subMul(this.m_invMassA, P);
-    wA -= this.m_invIA * Vec2.cross(this.m_rA, P);
+    wA -= this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, P);
     vB.addMul(this.m_invMassB, P);
-    wB += this.m_invIB * Vec2.cross(this.m_rB, P);
+    wB += this.m_invIB * Vec2.crossVec2Vec2(this.m_rB, P);
 
-    this.m_bodyA.c_velocity.v.set(vA);
+    this.m_bodyA.c_velocity.v.setVec2(vA);
     this.m_bodyA.c_velocity.w = wA;
-    this.m_bodyB.c_velocity.v.set(vB);
+    this.m_bodyB.c_velocity.v.setVec2(vB);
     this.m_bodyB.c_velocity.w = wB;
   }
 
@@ -432,16 +432,16 @@ export default class DistanceJoint extends Joint {
         .clamp(C, -Settings.maxLinearCorrection, Settings.maxLinearCorrection);
 
     const impulse = -this.m_mass * C;
-    const P = Vec2.mul(impulse, u);
+    const P = Vec2.mulNumberVec2(impulse, u);
 
     cA.subMul(this.m_invMassA, P);
-    aA -= this.m_invIA * Vec2.cross(rA, P);
+    aA -= this.m_invIA * Vec2.crossVec2Vec2(rA, P);
     cB.addMul(this.m_invMassB, P);
-    aB += this.m_invIB * Vec2.cross(rB, P);
+    aB += this.m_invIB * Vec2.crossVec2Vec2(rB, P);
 
-    this.m_bodyA.c_position.c.set(cA);
+    this.m_bodyA.c_position.c.setVec2(cA);
     this.m_bodyA.c_position.a = aA;
-    this.m_bodyB.c_position.c.set(cB);
+    this.m_bodyB.c_position.c.setVec2(cB);
     this.m_bodyB.c_position.a = aB;
 
     return Math.abs(C) < Settings.linearSlop;

--- a/src/dynamics/joint/DistanceJoint.ts
+++ b/src/dynamics/joint/DistanceJoint.ts
@@ -280,7 +280,7 @@ export default class DistanceJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mulNumberVec2(this.m_impulse, this.m_u).mul(inv_dt);
+    return Vec2.mulNumVec2(this.m_impulse, this.m_u).mul(inv_dt);
   }
 
   /**
@@ -360,7 +360,7 @@ export default class DistanceJoint extends Joint {
       // Scale the impulse to support a variable time step.
       this.m_impulse *= step.dtRatio;
 
-      const P = Vec2.mulNumberVec2(this.m_impulse, this.m_u);
+      const P = Vec2.mulNumVec2(this.m_impulse, this.m_u);
 
       vA.subMul(this.m_invMassA, P);
       wA -= this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, P);
@@ -385,15 +385,15 @@ export default class DistanceJoint extends Joint {
     let wB = this.m_bodyB.c_velocity.w;
 
     // Cdot = dot(u, v + cross(w, r))
-    const vpA = Vec2.add(vA, Vec2.crossNumberVec2(wA, this.m_rA));
-    const vpB = Vec2.add(vB, Vec2.crossNumberVec2(wB, this.m_rB));
+    const vpA = Vec2.add(vA, Vec2.crossNumVec2(wA, this.m_rA));
+    const vpB = Vec2.add(vB, Vec2.crossNumVec2(wB, this.m_rB));
     const Cdot = Vec2.dot(this.m_u, vpB) - Vec2.dot(this.m_u, vpA);
 
     const impulse = -this.m_mass
         * (Cdot + this.m_bias + this.m_gamma * this.m_impulse);
     this.m_impulse += impulse;
 
-    const P = Vec2.mulNumberVec2(impulse, this.m_u);
+    const P = Vec2.mulNumVec2(impulse, this.m_u);
     vA.subMul(this.m_invMassA, P);
     wA -= this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, P);
     vB.addMul(this.m_invMassB, P);
@@ -432,7 +432,7 @@ export default class DistanceJoint extends Joint {
         .clamp(C, -Settings.maxLinearCorrection, Settings.maxLinearCorrection);
 
     const impulse = -this.m_mass * C;
-    const P = Vec2.mulNumberVec2(impulse, u);
+    const P = Vec2.mulNumVec2(impulse, u);
 
     cA.subMul(this.m_invMassA, P);
     aA -= this.m_invIA * Vec2.crossVec2Vec2(rA, P);

--- a/src/dynamics/joint/DistanceJoint.ts
+++ b/src/dynamics/joint/DistanceJoint.ts
@@ -320,7 +320,7 @@ export default class DistanceJoint extends Joint {
     if (length > Settings.linearSlop) {
       this.m_u.mul(1.0 / length);
     } else {
-      this.m_u.set(0.0, 0.0);
+      this.m_u.setNum(0.0, 0.0);
     }
 
     const crAu = Vec2.crossVec2Vec2(this.m_rA, this.m_u);

--- a/src/dynamics/joint/FrictionJoint.ts
+++ b/src/dynamics/joint/FrictionJoint.ts
@@ -170,15 +170,15 @@ export default class FrictionJoint extends Joint {
     localAnchorB?: Vec2,
   }): void {
     if (def.anchorA) {
-      this.m_localAnchorA.set(this.m_bodyA.getLocalPoint(def.anchorA));
+      this.m_localAnchorA.setVec2(this.m_bodyA.getLocalPoint(def.anchorA));
     } else if (def.localAnchorA) {
-      this.m_localAnchorA.set(def.localAnchorA);
+      this.m_localAnchorA.setVec2(def.localAnchorA);
     }
 
     if (def.anchorB) {
-      this.m_localAnchorB.set(this.m_bodyB.getLocalPoint(def.anchorB));
+      this.m_localAnchorB.setVec2(this.m_bodyB.getLocalPoint(def.anchorB));
     } else if (def.localAnchorB) {
-      this.m_localAnchorB.set(def.localAnchorB);
+      this.m_localAnchorB.setVec2(def.localAnchorB);
     }
   }
 
@@ -245,7 +245,7 @@ export default class FrictionJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mul(inv_dt, this.m_linearImpulse);
+    return Vec2.mulNumberVec2(inv_dt, this.m_linearImpulse);
   }
 
   /**
@@ -315,10 +315,10 @@ export default class FrictionJoint extends Joint {
       const P = Vec2.neo(this.m_linearImpulse.x, this.m_linearImpulse.y);
 
       vA.subMul(mA, P);
-      wA -= iA * (Vec2.cross(this.m_rA, P) + this.m_angularImpulse);
+      wA -= iA * (Vec2.crossVec2Vec2(this.m_rA, P) + this.m_angularImpulse);
 
       vB.addMul(mB, P);
-      wB += iB * (Vec2.cross(this.m_rB, P) + this.m_angularImpulse);
+      wB += iB * (Vec2.crossVec2Vec2(this.m_rB, P) + this.m_angularImpulse);
 
     } else {
       this.m_linearImpulse.setZero();
@@ -361,8 +361,8 @@ export default class FrictionJoint extends Joint {
 
     // Solve linear friction
     {
-      const Cdot = Vec2.sub(Vec2.add(vB, Vec2.cross(wB, this.m_rB)), Vec2.add(vA,
-          Vec2.cross(wA, this.m_rA))); // Vec2
+      const Cdot = Vec2.sub(Vec2.add(vB, Vec2.crossNumberVec2(wB, this.m_rB)), Vec2.add(vA,
+          Vec2.crossNumberVec2(wA, this.m_rA))); // Vec2
 
       let impulse = Vec2.neg(Mat22.mulVec2(this.m_linearMass, Cdot)); // Vec2
       const oldImpulse = this.m_linearImpulse; // Vec2
@@ -378,10 +378,10 @@ export default class FrictionJoint extends Joint {
       impulse = Vec2.sub(this.m_linearImpulse, oldImpulse);
 
       vA.subMul(mA, impulse);
-      wA -= iA * Vec2.cross(this.m_rA, impulse);
+      wA -= iA * Vec2.crossVec2Vec2(this.m_rA, impulse);
 
       vB.addMul(mB, impulse);
-      wB += iB * Vec2.cross(this.m_rB, impulse);
+      wB += iB * Vec2.crossVec2Vec2(this.m_rB, impulse);
     }
 
     this.m_bodyA.c_velocity.v = vA;

--- a/src/dynamics/joint/FrictionJoint.ts
+++ b/src/dynamics/joint/FrictionJoint.ts
@@ -245,7 +245,7 @@ export default class FrictionJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mulNumberVec2(inv_dt, this.m_linearImpulse);
+    return Vec2.mulNumVec2(inv_dt, this.m_linearImpulse);
   }
 
   /**
@@ -361,8 +361,8 @@ export default class FrictionJoint extends Joint {
 
     // Solve linear friction
     {
-      const Cdot = Vec2.sub(Vec2.add(vB, Vec2.crossNumberVec2(wB, this.m_rB)), Vec2.add(vA,
-          Vec2.crossNumberVec2(wA, this.m_rA))); // Vec2
+      const Cdot = Vec2.sub(Vec2.add(vB, Vec2.crossNumVec2(wB, this.m_rB)), Vec2.add(vA,
+          Vec2.crossNumVec2(wA, this.m_rA))); // Vec2
 
       let impulse = Vec2.neg(Mat22.mulVec2(this.m_linearMass, Cdot)); // Vec2
       const oldImpulse = this.m_linearImpulse; // Vec2

--- a/src/dynamics/joint/GearJoint.ts
+++ b/src/dynamics/joint/GearJoint.ts
@@ -313,7 +313,7 @@ export default class GearJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mulNumberVec2(this.m_impulse, this.m_JvAC).mul(inv_dt);
+    return Vec2.mulNumVec2(this.m_impulse, this.m_JvAC).mul(inv_dt);
   }
 
   /**
@@ -385,7 +385,7 @@ export default class GearJoint extends Joint {
       const u = Rot.mulVec2(qD, this.m_localAxisD); // Vec2
       const rD = Rot.mulSub(qD, this.m_localAnchorD, this.m_lcD); // Vec2
       const rB = Rot.mulSub(qB, this.m_localAnchorB, this.m_lcB); // Vec2
-      this.m_JvBD = Vec2.mulNumberVec2(this.m_ratio, u);
+      this.m_JvBD = Vec2.mulNumVec2(this.m_ratio, u);
       this.m_JwD = this.m_ratio * Vec2.crossVec2Vec2(rD, u);
       this.m_JwB = this.m_ratio * Vec2.crossVec2Vec2(rB, u);
       this.m_mass += this.m_ratio * this.m_ratio * (this.m_mD + this.m_mB) + this.m_iD * this.m_JwD * this.m_JwD + this.m_iB * this.m_JwB * this.m_JwB;
@@ -521,7 +521,7 @@ export default class GearJoint extends Joint {
       const u = Rot.mulVec2(qD, this.m_localAxisD);
       const rD = Rot.mulSub(qD, this.m_localAnchorD, this.m_lcD);
       const rB = Rot.mulSub(qB, this.m_localAnchorB, this.m_lcB);
-      JvBD = Vec2.mulNumberVec2(this.m_ratio, u);
+      JvBD = Vec2.mulNumVec2(this.m_ratio, u);
       JwD = this.m_ratio * Vec2.crossVec2Vec2(rD, u);
       JwB = this.m_ratio * Vec2.crossVec2Vec2(rB, u);
       mass += this.m_ratio * this.m_ratio * (this.m_mD + this.m_mB) + this.m_iD

--- a/src/dynamics/joint/GearJoint.ts
+++ b/src/dynamics/joint/GearJoint.ts
@@ -313,7 +313,7 @@ export default class GearJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mul(this.m_impulse, this.m_JvAC).mul(inv_dt);
+    return Vec2.mulNumberVec2(this.m_impulse, this.m_JvAC).mul(inv_dt);
   }
 
   /**
@@ -371,8 +371,8 @@ export default class GearJoint extends Joint {
       const rC = Rot.mulSub(qC, this.m_localAnchorC, this.m_lcC); // Vec2
       const rA = Rot.mulSub(qA, this.m_localAnchorA, this.m_lcA); // Vec2
       this.m_JvAC = u;
-      this.m_JwC = Vec2.cross(rC, u);
-      this.m_JwA = Vec2.cross(rA, u);
+      this.m_JwC = Vec2.crossVec2Vec2(rC, u);
+      this.m_JwA = Vec2.crossVec2Vec2(rA, u);
       this.m_mass += this.m_mC + this.m_mA + this.m_iC * this.m_JwC * this.m_JwC + this.m_iA * this.m_JwA * this.m_JwA;
     }
 
@@ -385,9 +385,9 @@ export default class GearJoint extends Joint {
       const u = Rot.mulVec2(qD, this.m_localAxisD); // Vec2
       const rD = Rot.mulSub(qD, this.m_localAnchorD, this.m_lcD); // Vec2
       const rB = Rot.mulSub(qB, this.m_localAnchorB, this.m_lcB); // Vec2
-      this.m_JvBD = Vec2.mul(this.m_ratio, u);
-      this.m_JwD = this.m_ratio * Vec2.cross(rD, u);
-      this.m_JwB = this.m_ratio * Vec2.cross(rB, u);
+      this.m_JvBD = Vec2.mulNumberVec2(this.m_ratio, u);
+      this.m_JwD = this.m_ratio * Vec2.crossVec2Vec2(rD, u);
+      this.m_JwB = this.m_ratio * Vec2.crossVec2Vec2(rB, u);
       this.m_mass += this.m_ratio * this.m_ratio * (this.m_mD + this.m_mB) + this.m_iD * this.m_JwD * this.m_JwD + this.m_iB * this.m_JwB * this.m_JwB;
     }
 
@@ -411,13 +411,13 @@ export default class GearJoint extends Joint {
       this.m_impulse = 0.0;
     }
 
-    this.m_bodyA.c_velocity.v.set(vA);
+    this.m_bodyA.c_velocity.v.setVec2(vA);
     this.m_bodyA.c_velocity.w = wA;
-    this.m_bodyB.c_velocity.v.set(vB);
+    this.m_bodyB.c_velocity.v.setVec2(vB);
     this.m_bodyB.c_velocity.w = wB;
-    this.m_bodyC.c_velocity.v.set(vC);
+    this.m_bodyC.c_velocity.v.setVec2(vC);
     this.m_bodyC.c_velocity.w = wC;
-    this.m_bodyD.c_velocity.v.set(vD);
+    this.m_bodyD.c_velocity.v.setVec2(vD);
     this.m_bodyD.c_velocity.w = wD;
   }
 
@@ -448,13 +448,13 @@ export default class GearJoint extends Joint {
     vD.subMul(this.m_mD * impulse, this.m_JvBD);
     wD -= this.m_iD * impulse * this.m_JwD;
 
-    this.m_bodyA.c_velocity.v.set(vA);
+    this.m_bodyA.c_velocity.v.setVec2(vA);
     this.m_bodyA.c_velocity.w = wA;
-    this.m_bodyB.c_velocity.v.set(vB);
+    this.m_bodyB.c_velocity.v.setVec2(vB);
     this.m_bodyB.c_velocity.w = wB;
-    this.m_bodyC.c_velocity.v.set(vC);
+    this.m_bodyC.c_velocity.v.setVec2(vC);
     this.m_bodyC.c_velocity.w = wC;
-    this.m_bodyD.c_velocity.v.set(vD);
+    this.m_bodyD.c_velocity.v.setVec2(vD);
     this.m_bodyD.c_velocity.w = wD;
   }
 
@@ -501,8 +501,8 @@ export default class GearJoint extends Joint {
       const rC = Rot.mulSub(qC, this.m_localAnchorC, this.m_lcC); // Vec2
       const rA = Rot.mulSub(qA, this.m_localAnchorA, this.m_lcA); // Vec2
       JvAC = u;
-      JwC = Vec2.cross(rC, u);
-      JwA = Vec2.cross(rA, u);
+      JwC = Vec2.crossVec2Vec2(rC, u);
+      JwA = Vec2.crossVec2Vec2(rA, u);
       mass += this.m_mC + this.m_mA + this.m_iC * JwC * JwC + this.m_iA * JwA * JwA;
 
       const pC = Vec2.sub(this.m_localAnchorC, this.m_lcC); // Vec2
@@ -521,9 +521,9 @@ export default class GearJoint extends Joint {
       const u = Rot.mulVec2(qD, this.m_localAxisD);
       const rD = Rot.mulSub(qD, this.m_localAnchorD, this.m_lcD);
       const rB = Rot.mulSub(qB, this.m_localAnchorB, this.m_lcB);
-      JvBD = Vec2.mul(this.m_ratio, u);
-      JwD = this.m_ratio * Vec2.cross(rD, u);
-      JwB = this.m_ratio * Vec2.cross(rB, u);
+      JvBD = Vec2.mulNumberVec2(this.m_ratio, u);
+      JwD = this.m_ratio * Vec2.crossVec2Vec2(rD, u);
+      JwB = this.m_ratio * Vec2.crossVec2Vec2(rB, u);
       mass += this.m_ratio * this.m_ratio * (this.m_mD + this.m_mB) + this.m_iD
           * JwD * JwD + this.m_iB * JwB * JwB;
 
@@ -549,13 +549,13 @@ export default class GearJoint extends Joint {
     cD.subMul(this.m_mD * impulse, JvBD);
     aD -= this.m_iD * impulse * JwD;
 
-    this.m_bodyA.c_position.c.set(cA);
+    this.m_bodyA.c_position.c.setVec2(cA);
     this.m_bodyA.c_position.a = aA;
-    this.m_bodyB.c_position.c.set(cB);
+    this.m_bodyB.c_position.c.setVec2(cB);
     this.m_bodyB.c_position.a = aB;
-    this.m_bodyC.c_position.c.set(cC);
+    this.m_bodyC.c_position.c.setVec2(cC);
     this.m_bodyC.c_position.a = aC;
-    this.m_bodyD.c_position.c.set(cD);
+    this.m_bodyD.c_position.c.setVec2(cD);
     this.m_bodyD.c_position.a = aD;
 
     // TODO_ERIN not implemented

--- a/src/dynamics/joint/GearJoint.ts
+++ b/src/dynamics/joint/GearJoint.ts
@@ -181,7 +181,7 @@ export default class GearJoint extends Joint {
       this.m_localAxisC = prismatic.m_localXAxisA;
 
       const pC = this.m_localAnchorC;
-      const pA = Rot.mulTVec2(xfC.q, Vec2.add(Rot.mul(xfA.q, this.m_localAnchorA), Vec2.sub(xfA.p, xfC.p)));
+      const pA = Rot.mulTVec2(xfC.q, Vec2.add(Rot.mulVec2(xfA.q, this.m_localAnchorA), Vec2.sub(xfA.p, xfC.p)));
       coordinateA = Vec2.dot(pA, this.m_localAxisC) - Vec2.dot(pC, this.m_localAxisC);
     }
 
@@ -210,7 +210,7 @@ export default class GearJoint extends Joint {
       this.m_localAxisD = prismatic.m_localXAxisA;
 
       const pD = this.m_localAnchorD;
-      const pB = Rot.mulTVec2(xfD.q, Vec2.add(Rot.mul(xfB.q, this.m_localAnchorB), Vec2.sub(xfB.p, xfD.p)));
+      const pB = Rot.mulTVec2(xfD.q, Vec2.add(Rot.mulVec2(xfB.q, this.m_localAnchorB), Vec2.sub(xfB.p, xfD.p)));
       coordinateB = Vec2.dot(pB, this.m_localAxisD) - Vec2.dot(pD, this.m_localAxisD);
     }
 

--- a/src/dynamics/joint/MotorJoint.ts
+++ b/src/dynamics/joint/MotorJoint.ts
@@ -266,7 +266,7 @@ export default class MotorJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mul(inv_dt, this.m_linearImpulse);
+    return Vec2.mulNumberVec2(inv_dt, this.m_linearImpulse);
   }
 
   /**
@@ -343,10 +343,10 @@ export default class MotorJoint extends Joint {
       const P = Vec2.neo(this.m_linearImpulse.x, this.m_linearImpulse.y);
 
       vA.subMul(mA, P);
-      wA -= iA * (Vec2.cross(this.m_rA, P) + this.m_angularImpulse);
+      wA -= iA * (Vec2.crossVec2Vec2(this.m_rA, P) + this.m_angularImpulse);
 
       vB.addMul(mB, P);
-      wB += iB * (Vec2.cross(this.m_rB, P) + this.m_angularImpulse);
+      wB += iB * (Vec2.crossVec2Vec2(this.m_rB, P) + this.m_angularImpulse);
 
     } else {
       this.m_linearImpulse.setZero();
@@ -391,8 +391,8 @@ export default class MotorJoint extends Joint {
     // Solve linear friction
     {
       const Cdot = Vec2.zero();
-      Cdot.addCombine(1, vB, 1, Vec2.cross(wB, this.m_rB));
-      Cdot.subCombine(1, vA, 1, Vec2.cross(wA, this.m_rA));
+      Cdot.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
+      Cdot.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA));
       Cdot.addMul(inv_h * this.m_correctionFactor, this.m_linearError);
 
       let impulse = Vec2.neg(Mat22.mulVec2(this.m_linearMass, Cdot));
@@ -406,10 +406,10 @@ export default class MotorJoint extends Joint {
       impulse = Vec2.sub(this.m_linearImpulse, oldImpulse);
 
       vA.subMul(mA, impulse);
-      wA -= iA * Vec2.cross(this.m_rA, impulse);
+      wA -= iA * Vec2.crossVec2Vec2(this.m_rA, impulse);
 
       vB.addMul(mB, impulse);
-      wB += iB * Vec2.cross(this.m_rB, impulse);
+      wB += iB * Vec2.crossVec2Vec2(this.m_rB, impulse);
     }
 
     this.m_bodyA.c_velocity.v = vA;

--- a/src/dynamics/joint/MotorJoint.ts
+++ b/src/dynamics/joint/MotorJoint.ts
@@ -266,7 +266,7 @@ export default class MotorJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mulNumberVec2(inv_dt, this.m_linearImpulse);
+    return Vec2.mulNumVec2(inv_dt, this.m_linearImpulse);
   }
 
   /**
@@ -391,8 +391,8 @@ export default class MotorJoint extends Joint {
     // Solve linear friction
     {
       const Cdot = Vec2.zero();
-      Cdot.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
-      Cdot.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA));
+      Cdot.addCombine(1, vB, 1, Vec2.crossNumVec2(wB, this.m_rB));
+      Cdot.subCombine(1, vA, 1, Vec2.crossNumVec2(wA, this.m_rA));
       Cdot.addMul(inv_h * this.m_correctionFactor, this.m_linearError);
 
       let impulse = Vec2.neg(Mat22.mulVec2(this.m_linearMass, Cdot));

--- a/src/dynamics/joint/MouseJoint.ts
+++ b/src/dynamics/joint/MouseJoint.ts
@@ -175,7 +175,7 @@ export default class MouseJoint extends Joint {
     data = {...data};
     data.bodyA = restore(Body, data.bodyA, world);
     data.bodyB = restore(Body, data.bodyB, world);
-    data.target = new Vec2(data.target);
+    data.target = Vec2.clone(data.target);
     const joint = new MouseJoint(data);
     if (data._localAnchorB) {
       joint.m_localAnchorB = data._localAnchorB;
@@ -257,7 +257,7 @@ export default class MouseJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mul(inv_dt, this.m_impulse);
+    return Vec2.mulNumberVec2(inv_dt, this.m_impulse);
   }
 
   /**
@@ -329,7 +329,7 @@ export default class MouseJoint extends Joint {
 
     this.m_mass = K.getInverse();
 
-    this.m_C.set(cB);
+    this.m_C.setVec2(cB);
     this.m_C.addCombine(1, this.m_rB, -1, this.m_targetA);
     this.m_C.mul(this.m_beta);
 
@@ -339,13 +339,13 @@ export default class MouseJoint extends Joint {
     if (step.warmStarting) {
       this.m_impulse.mul(step.dtRatio);
       vB.addMul(this.m_invMassB, this.m_impulse);
-      wB += this.m_invIB * Vec2.cross(this.m_rB, this.m_impulse);
+      wB += this.m_invIB * Vec2.crossVec2Vec2(this.m_rB, this.m_impulse);
 
     } else {
       this.m_impulse.setZero();
     }
 
-    velocity.v.set(vB);
+    velocity.v.setVec2(vB);
     velocity.w = wB;
   }
 
@@ -356,7 +356,7 @@ export default class MouseJoint extends Joint {
 
     // Cdot = v + cross(w, r)
 
-    const Cdot = Vec2.cross(wB, this.m_rB);
+    const Cdot = Vec2.crossNumberVec2(wB, this.m_rB);
     Cdot.add(vB);
 
     Cdot.addCombine(1, this.m_C, this.m_gamma, this.m_impulse);
@@ -371,9 +371,9 @@ export default class MouseJoint extends Joint {
     impulse = Vec2.sub(this.m_impulse, oldImpulse);
 
     vB.addMul(this.m_invMassB, impulse);
-    wB += this.m_invIB * Vec2.cross(this.m_rB, impulse);
+    wB += this.m_invIB * Vec2.crossVec2Vec2(this.m_rB, impulse);
 
-    velocity.v.set(vB);
+    velocity.v.setVec2(vB);
     velocity.w = wB;
   }
 

--- a/src/dynamics/joint/MouseJoint.ts
+++ b/src/dynamics/joint/MouseJoint.ts
@@ -257,7 +257,7 @@ export default class MouseJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mulNumberVec2(inv_dt, this.m_impulse);
+    return Vec2.mulNumVec2(inv_dt, this.m_impulse);
   }
 
   /**
@@ -356,7 +356,7 @@ export default class MouseJoint extends Joint {
 
     // Cdot = v + cross(w, r)
 
-    const Cdot = Vec2.crossNumberVec2(wB, this.m_rB);
+    const Cdot = Vec2.crossNumVec2(wB, this.m_rB);
     Cdot.add(vB);
 
     Cdot.addCombine(1, this.m_C, this.m_gamma, this.m_impulse);

--- a/src/dynamics/joint/PrismaticJoint.ts
+++ b/src/dynamics/joint/PrismaticJoint.ts
@@ -174,7 +174,7 @@ export default class PrismaticJoint extends Joint {
     this.m_localAnchorB = Vec2.clone(anchor ? bodyB.getLocalPoint(anchor) : def.localAnchorB || Vec2.zero());
     this.m_localXAxisA = Vec2.clone(axis ? bodyA.getLocalVector(axis) : def.localAxisA || Vec2.neo(1.0, 0.0));
     this.m_localXAxisA.normalize();
-    this.m_localYAxisA = Vec2.crossNumberVec2(1.0, this.m_localXAxisA);
+    this.m_localYAxisA = Vec2.crossNumVec2(1.0, this.m_localXAxisA);
     this.m_referenceAngle = Math.isFinite(def.referenceAngle) ? def.referenceAngle : bodyB.getAngle() - bodyA.getAngle();
 
     this.m_impulse = new Vec3();
@@ -320,7 +320,7 @@ export default class PrismaticJoint extends Joint {
 
     if (def.localAxisA) {
       this.m_localXAxisA.setVec2(def.localAxisA);
-      this.m_localYAxisA.setVec2(Vec2.crossNumberVec2(1.0, def.localAxisA));
+      this.m_localYAxisA.setVec2(Vec2.crossNumVec2(1.0, def.localAxisA));
     }
   }
 
@@ -384,8 +384,8 @@ export default class PrismaticJoint extends Joint {
     const wA = bA.m_angularVelocity; // float
     const wB = bB.m_angularVelocity; // float
 
-    const speed = Vec2.dot(d, Vec2.crossNumberVec2(wA, axis))
-        + Vec2.dot(axis, Vec2.sub(Vec2.addCrossNumberVec2(vB, wB, rB), Vec2.addCrossNumberVec2(vA, wA, rA))); // float
+    const speed = Vec2.dot(d, Vec2.crossNumVec2(wA, axis))
+        + Vec2.dot(axis, Vec2.sub(Vec2.addCrossNumVec2(vB, wB, rB), Vec2.addCrossNumVec2(vA, wA, rA))); // float
     return speed;
   }
 
@@ -670,7 +670,7 @@ export default class PrismaticJoint extends Joint {
           -maxImpulse, maxImpulse);
       impulse = this.m_motorImpulse - oldImpulse;
 
-      const P = Vec2.mulNumberVec2(impulse, this.m_axis);
+      const P = Vec2.mulNumVec2(impulse, this.m_axis);
       const LA = impulse * this.m_a1;
       const LB = impulse * this.m_a2;
 
@@ -728,7 +728,7 @@ export default class PrismaticJoint extends Joint {
       this.m_impulse.x += df.x;
       this.m_impulse.y += df.y;
 
-      const P = Vec2.mulNumberVec2(df.x, this.m_perp); // Vec2
+      const P = Vec2.mulNumVec2(df.x, this.m_perp); // Vec2
       const LA = df.x * this.m_s1 + df.y; // float
       const LB = df.x * this.m_s2 + df.y; // float
 

--- a/src/dynamics/joint/PrismaticJoint.ts
+++ b/src/dynamics/joint/PrismaticJoint.ts
@@ -847,8 +847,8 @@ export default class PrismaticJoint extends Joint {
       }
 
       const K = new Mat22();
-      K.ex.set(k11, k12);
-      K.ey.set(k12, k22);
+      K.ex.setNum(k11, k12);
+      K.ey.setNum(k12, k22);
 
       const impulse1 = K.solve(Vec2.neg(C1)); // Vec2
       impulse.x = impulse1.x;

--- a/src/dynamics/joint/PrismaticJoint.ts
+++ b/src/dynamics/joint/PrismaticJoint.ts
@@ -174,7 +174,7 @@ export default class PrismaticJoint extends Joint {
     this.m_localAnchorB = Vec2.clone(anchor ? bodyB.getLocalPoint(anchor) : def.localAnchorB || Vec2.zero());
     this.m_localXAxisA = Vec2.clone(axis ? bodyA.getLocalVector(axis) : def.localAxisA || Vec2.neo(1.0, 0.0));
     this.m_localXAxisA.normalize();
-    this.m_localYAxisA = Vec2.cross(1.0, this.m_localXAxisA);
+    this.m_localYAxisA = Vec2.crossNumberVec2(1.0, this.m_localXAxisA);
     this.m_referenceAngle = Math.isFinite(def.referenceAngle) ? def.referenceAngle : bodyB.getAngle() - bodyA.getAngle();
 
     this.m_impulse = new Vec3();
@@ -293,7 +293,7 @@ export default class PrismaticJoint extends Joint {
     data = {...data};
     data.bodyA = restore(Body, data.bodyA, world);
     data.bodyB = restore(Body, data.bodyB, world);
-    data.localAxisA = new Vec2(data.localAxisA);
+    data.localAxisA = Vec2.clone(data.localAxisA);
     const joint = new PrismaticJoint(data);
     return joint;
   }
@@ -307,20 +307,20 @@ export default class PrismaticJoint extends Joint {
     localAxisA?: Vec2,
   }): void {
     if (def.anchorA) {
-      this.m_localAnchorA.set(this.m_bodyA.getLocalPoint(def.anchorA));
+      this.m_localAnchorA.setVec2(this.m_bodyA.getLocalPoint(def.anchorA));
     } else if (def.localAnchorA) {
-      this.m_localAnchorA.set(def.localAnchorA);
+      this.m_localAnchorA.setVec2(def.localAnchorA);
     }
 
     if (def.anchorB) {
-      this.m_localAnchorB.set(this.m_bodyB.getLocalPoint(def.anchorB));
+      this.m_localAnchorB.setVec2(this.m_bodyB.getLocalPoint(def.anchorB));
     } else if (def.localAnchorB) {
-      this.m_localAnchorB.set(def.localAnchorB);
+      this.m_localAnchorB.setVec2(def.localAnchorB);
     }
 
     if (def.localAxisA) {
-      this.m_localXAxisA.set(def.localAxisA);
-      this.m_localYAxisA.set(Vec2.cross(1.0, def.localAxisA));
+      this.m_localXAxisA.setVec2(def.localAxisA);
+      this.m_localYAxisA.setVec2(Vec2.crossNumberVec2(1.0, def.localAxisA));
     }
   }
 
@@ -384,8 +384,8 @@ export default class PrismaticJoint extends Joint {
     const wA = bA.m_angularVelocity; // float
     const wB = bB.m_angularVelocity; // float
 
-    const speed = Vec2.dot(d, Vec2.cross(wA, axis))
-        + Vec2.dot(axis, Vec2.sub(Vec2.addCross(vB, wB, rB), Vec2.addCross(vA, wA, rA))); // float
+    const speed = Vec2.dot(d, Vec2.crossNumberVec2(wA, axis))
+        + Vec2.dot(axis, Vec2.sub(Vec2.addCrossNumberVec2(vB, wB, rB), Vec2.addCrossNumberVec2(vA, wA, rA))); // float
     return speed;
   }
 
@@ -552,8 +552,8 @@ export default class PrismaticJoint extends Joint {
     // Compute motor Jacobian and effective mass.
     {
       this.m_axis = Rot.mulVec2(qA, this.m_localXAxisA);
-      this.m_a1 = Vec2.cross(Vec2.add(d, rA), this.m_axis);
-      this.m_a2 = Vec2.cross(rB, this.m_axis);
+      this.m_a1 = Vec2.crossVec2Vec2(Vec2.add(d, rA), this.m_axis);
+      this.m_a2 = Vec2.crossVec2Vec2(rB, this.m_axis);
 
       this.m_motorMass = mA + mB + iA * this.m_a1 * this.m_a1 + iB * this.m_a2
           * this.m_a2;
@@ -566,10 +566,10 @@ export default class PrismaticJoint extends Joint {
     {
       this.m_perp = Rot.mulVec2(qA, this.m_localYAxisA);
 
-      this.m_s1 = Vec2.cross(Vec2.add(d, rA), this.m_perp);
-      this.m_s2 = Vec2.cross(rB, this.m_perp);
+      this.m_s1 = Vec2.crossVec2Vec2(Vec2.add(d, rA), this.m_perp);
+      this.m_s2 = Vec2.crossVec2Vec2(rB, this.m_perp);
 
-      const s1test = Vec2.cross(rA, this.m_perp);
+      const s1test = Vec2.crossVec2Vec2(rA, this.m_perp);
 
       const k11 = mA + mB + iA * this.m_s1 * this.m_s1 + iB * this.m_s2 * this.m_s2;
       const k12 = iA * this.m_s1 + iB * this.m_s2;
@@ -642,9 +642,9 @@ export default class PrismaticJoint extends Joint {
       this.m_motorImpulse = 0.0;
     }
 
-    this.m_bodyA.c_velocity.v.set(vA);
+    this.m_bodyA.c_velocity.v.setVec2(vA);
     this.m_bodyA.c_velocity.w = wA;
-    this.m_bodyB.c_velocity.v.set(vB);
+    this.m_bodyB.c_velocity.v.setVec2(vB);
     this.m_bodyB.c_velocity.w = wB;
   }
 
@@ -670,7 +670,7 @@ export default class PrismaticJoint extends Joint {
           -maxImpulse, maxImpulse);
       impulse = this.m_motorImpulse - oldImpulse;
 
-      const P = Vec2.mul(impulse, this.m_axis);
+      const P = Vec2.mulNumberVec2(impulse, this.m_axis);
       const LA = impulse * this.m_a1;
       const LB = impulse * this.m_a2;
 
@@ -728,7 +728,7 @@ export default class PrismaticJoint extends Joint {
       this.m_impulse.x += df.x;
       this.m_impulse.y += df.y;
 
-      const P = Vec2.mul(df.x, this.m_perp); // Vec2
+      const P = Vec2.mulNumberVec2(df.x, this.m_perp); // Vec2
       const LA = df.x * this.m_s1 + df.y; // float
       const LB = df.x * this.m_s2 + df.y; // float
 
@@ -768,12 +768,12 @@ export default class PrismaticJoint extends Joint {
     const d = Vec2.sub(Vec2.add(cB, rB), Vec2.add(cA, rA)); // Vec2
 
     const axis = Rot.mulVec2(qA, this.m_localXAxisA); // Vec2
-    const a1 = Vec2.cross(Vec2.add(d, rA), axis); // float
-    const a2 = Vec2.cross(rB, axis); // float
+    const a1 = Vec2.crossVec2Vec2(Vec2.add(d, rA), axis); // float
+    const a2 = Vec2.crossVec2Vec2(rB, axis); // float
     const perp = Rot.mulVec2(qA, this.m_localYAxisA); // Vec2
 
-    const s1 = Vec2.cross(Vec2.add(d, rA), perp); // float
-    const s2 = Vec2.cross(rB, perp); // float
+    const s1 = Vec2.crossVec2Vec2(Vec2.add(d, rA), perp); // float
+    const s2 = Vec2.crossVec2Vec2(rB, perp); // float
 
     let impulse = new Vec3();
     const C1 = Vec2.zero(); // Vec2

--- a/src/dynamics/joint/PrismaticJoint.ts
+++ b/src/dynamics/joint/PrismaticJoint.ts
@@ -694,7 +694,7 @@ export default class PrismaticJoint extends Joint {
 
       const Cdot = new Vec3(Cdot1.x, Cdot1.y, Cdot2);
 
-      const f1 = new Vec3(this.m_impulse);
+      const f1 = Vec3.clone(this.m_impulse);
       let df = this.m_K.solve33(Vec3.neg(Cdot)); // Vec3
       this.m_impulse.add(df);
 

--- a/src/dynamics/joint/PulleyJoint.ts
+++ b/src/dynamics/joint/PulleyJoint.ts
@@ -270,7 +270,7 @@ export default class PulleyJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mul(this.m_impulse, this.m_uB).mul(inv_dt);
+    return Vec2.mulNumberVec2(this.m_impulse, this.m_uB).mul(inv_dt);
   }
 
   /**
@@ -324,8 +324,8 @@ export default class PulleyJoint extends Joint {
     }
 
     // Compute effective mass.
-    const ruA = Vec2.cross(this.m_rA, this.m_uA); // float
-    const ruB = Vec2.cross(this.m_rB, this.m_uB); // float
+    const ruA = Vec2.crossVec2Vec2(this.m_rA, this.m_uA); // float
+    const ruB = Vec2.crossVec2Vec2(this.m_rB, this.m_uB); // float
 
     const mA = this.m_invMassA + this.m_invIA * ruA * ruA; // float
     const mB = this.m_invMassB + this.m_invIB * ruB * ruB; // float
@@ -341,14 +341,14 @@ export default class PulleyJoint extends Joint {
       this.m_impulse *= step.dtRatio;
 
       // Warm starting.
-      const PA = Vec2.mul(-this.m_impulse, this.m_uA);
-      const PB = Vec2.mul(-this.m_ratio * this.m_impulse, this.m_uB);
+      const PA = Vec2.mulNumberVec2(-this.m_impulse, this.m_uA);
+      const PB = Vec2.mulNumberVec2(-this.m_ratio * this.m_impulse, this.m_uB);
 
       vA.addMul(this.m_invMassA, PA);
-      wA += this.m_invIA * Vec2.cross(this.m_rA, PA);
+      wA += this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, PA);
 
       vB.addMul(this.m_invMassB, PB);
-      wB += this.m_invIB * Vec2.cross(this.m_rB, PB);
+      wB += this.m_invIB * Vec2.crossVec2Vec2(this.m_rB, PB);
 
     } else {
       this.m_impulse = 0.0;
@@ -366,20 +366,20 @@ export default class PulleyJoint extends Joint {
     const vB = this.m_bodyB.c_velocity.v;
     let wB = this.m_bodyB.c_velocity.w;
 
-    const vpA = Vec2.add(vA, Vec2.cross(wA, this.m_rA));
-    const vpB = Vec2.add(vB, Vec2.cross(wB, this.m_rB));
+    const vpA = Vec2.add(vA, Vec2.crossNumberVec2(wA, this.m_rA));
+    const vpB = Vec2.add(vB, Vec2.crossNumberVec2(wB, this.m_rB));
 
     const Cdot = -Vec2.dot(this.m_uA, vpA) - this.m_ratio
         * Vec2.dot(this.m_uB, vpB); // float
     const impulse = -this.m_mass * Cdot; // float
     this.m_impulse += impulse;
 
-    const PA = Vec2.mul(-impulse, this.m_uA); // Vec2
-    const PB = Vec2.mul(-this.m_ratio * impulse, this.m_uB); // Vec2
+    const PA = Vec2.mulNumberVec2(-impulse, this.m_uA); // Vec2
+    const PB = Vec2.mulNumberVec2(-this.m_ratio * impulse, this.m_uB); // Vec2
     vA.addMul(this.m_invMassA, PA);
-    wA += this.m_invIA * Vec2.cross(this.m_rA, PA);
+    wA += this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, PA);
     vB.addMul(this.m_invMassB, PB);
-    wB += this.m_invIB * Vec2.cross(this.m_rB, PB);
+    wB += this.m_invIB * Vec2.crossVec2Vec2(this.m_rB, PB);
 
     this.m_bodyA.c_velocity.v = vA;
     this.m_bodyA.c_velocity.w = wA;
@@ -422,8 +422,8 @@ export default class PulleyJoint extends Joint {
     }
 
     // Compute effective mass.
-    const ruA = Vec2.cross(rA, uA);
-    const ruB = Vec2.cross(rB, uB);
+    const ruA = Vec2.crossVec2Vec2(rA, uA);
+    const ruB = Vec2.crossVec2Vec2(rB, uB);
 
     const mA = this.m_invMassA + this.m_invIA * ruA * ruA; // float
     const mB = this.m_invMassB + this.m_invIB * ruB * ruB; // float
@@ -439,13 +439,13 @@ export default class PulleyJoint extends Joint {
 
     const impulse = -mass * C; // float
 
-    const PA = Vec2.mul(-impulse, uA); // Vec2
-    const PB = Vec2.mul(-this.m_ratio * impulse, uB); // Vec2
+    const PA = Vec2.mulNumberVec2(-impulse, uA); // Vec2
+    const PB = Vec2.mulNumberVec2(-this.m_ratio * impulse, uB); // Vec2
 
     cA.addMul(this.m_invMassA, PA);
-    aA += this.m_invIA * Vec2.cross(rA, PA);
+    aA += this.m_invIA * Vec2.crossVec2Vec2(rA, PA);
     cB.addMul(this.m_invMassB, PB);
-    aB += this.m_invIB * Vec2.cross(rB, PB);
+    aB += this.m_invIB * Vec2.crossVec2Vec2(rB, PB);
 
     this.m_bodyA.c_position.c = cA;
     this.m_bodyA.c_position.a = aA;

--- a/src/dynamics/joint/PulleyJoint.ts
+++ b/src/dynamics/joint/PulleyJoint.ts
@@ -270,7 +270,7 @@ export default class PulleyJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mulNumberVec2(this.m_impulse, this.m_uB).mul(inv_dt);
+    return Vec2.mulNumVec2(this.m_impulse, this.m_uB).mul(inv_dt);
   }
 
   /**
@@ -341,8 +341,8 @@ export default class PulleyJoint extends Joint {
       this.m_impulse *= step.dtRatio;
 
       // Warm starting.
-      const PA = Vec2.mulNumberVec2(-this.m_impulse, this.m_uA);
-      const PB = Vec2.mulNumberVec2(-this.m_ratio * this.m_impulse, this.m_uB);
+      const PA = Vec2.mulNumVec2(-this.m_impulse, this.m_uA);
+      const PB = Vec2.mulNumVec2(-this.m_ratio * this.m_impulse, this.m_uB);
 
       vA.addMul(this.m_invMassA, PA);
       wA += this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, PA);
@@ -366,16 +366,16 @@ export default class PulleyJoint extends Joint {
     const vB = this.m_bodyB.c_velocity.v;
     let wB = this.m_bodyB.c_velocity.w;
 
-    const vpA = Vec2.add(vA, Vec2.crossNumberVec2(wA, this.m_rA));
-    const vpB = Vec2.add(vB, Vec2.crossNumberVec2(wB, this.m_rB));
+    const vpA = Vec2.add(vA, Vec2.crossNumVec2(wA, this.m_rA));
+    const vpB = Vec2.add(vB, Vec2.crossNumVec2(wB, this.m_rB));
 
     const Cdot = -Vec2.dot(this.m_uA, vpA) - this.m_ratio
         * Vec2.dot(this.m_uB, vpB); // float
     const impulse = -this.m_mass * Cdot; // float
     this.m_impulse += impulse;
 
-    const PA = Vec2.mulNumberVec2(-impulse, this.m_uA); // Vec2
-    const PB = Vec2.mulNumberVec2(-this.m_ratio * impulse, this.m_uB); // Vec2
+    const PA = Vec2.mulNumVec2(-impulse, this.m_uA); // Vec2
+    const PB = Vec2.mulNumVec2(-this.m_ratio * impulse, this.m_uB); // Vec2
     vA.addMul(this.m_invMassA, PA);
     wA += this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, PA);
     vB.addMul(this.m_invMassB, PB);
@@ -439,8 +439,8 @@ export default class PulleyJoint extends Joint {
 
     const impulse = -mass * C; // float
 
-    const PA = Vec2.mulNumberVec2(-impulse, uA); // Vec2
-    const PB = Vec2.mulNumberVec2(-this.m_ratio * impulse, uB); // Vec2
+    const PA = Vec2.mulNumVec2(-impulse, uA); // Vec2
+    const PB = Vec2.mulNumVec2(-this.m_ratio * impulse, uB); // Vec2
 
     cA.addMul(this.m_invMassA, PA);
     aA += this.m_invIA * Vec2.crossVec2Vec2(rA, PA);

--- a/src/dynamics/joint/RevoluteJoint.ts
+++ b/src/dynamics/joint/RevoluteJoint.ts
@@ -240,15 +240,15 @@ export default class RevoluteJoint extends Joint {
     localAnchorB?: Vec2,
   }): void {
     if (def.anchorA) {
-      this.m_localAnchorA.set(this.m_bodyA.getLocalPoint(def.anchorA));
+      this.m_localAnchorA.setVec2(this.m_bodyA.getLocalPoint(def.anchorA));
     } else if (def.localAnchorA) {
-      this.m_localAnchorA.set(def.localAnchorA);
+      this.m_localAnchorA.setVec2(def.localAnchorA);
     }
 
     if (def.anchorB) {
-      this.m_localAnchorB.set(this.m_bodyB.getLocalPoint(def.anchorB));
+      this.m_localAnchorB.setVec2(this.m_bodyB.getLocalPoint(def.anchorB));
     } else if (def.localAnchorB) {
-      this.m_localAnchorB.set(def.localAnchorB);
+      this.m_localAnchorB.setVec2(def.localAnchorB);
     }
   }
 
@@ -515,10 +515,10 @@ export default class RevoluteJoint extends Joint {
       const P = Vec2.neo(this.m_impulse.x, this.m_impulse.y);
 
       vA.subMul(mA, P);
-      wA -= iA * (Vec2.cross(this.m_rA, P) + this.m_motorImpulse + this.m_impulse.z);
+      wA -= iA * (Vec2.crossVec2Vec2(this.m_rA, P) + this.m_motorImpulse + this.m_impulse.z);
 
       vB.addMul(mB, P);
-      wB += iB * (Vec2.cross(this.m_rB, P) + this.m_motorImpulse + this.m_impulse.z);
+      wB += iB * (Vec2.crossVec2Vec2(this.m_rB, P) + this.m_motorImpulse + this.m_impulse.z);
 
     } else {
       this.m_impulse.setZero();
@@ -563,8 +563,8 @@ export default class RevoluteJoint extends Joint {
     if (this.m_enableLimit && this.m_limitState != inactiveLimit
         && fixedRotation == false) {
       const Cdot1 = Vec2.zero();
-      Cdot1.addCombine(1, vB, 1, Vec2.cross(wB, this.m_rB));
-      Cdot1.subCombine(1, vA, 1, Vec2.cross(wA, this.m_rA));
+      Cdot1.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
+      Cdot1.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA));
       const Cdot2 = wB - wA; // float
       const Cdot = new Vec3(Cdot1.x, Cdot1.y, Cdot2);
 
@@ -611,26 +611,26 @@ export default class RevoluteJoint extends Joint {
       const P = Vec2.neo(impulse.x, impulse.y);
 
       vA.subMul(mA, P);
-      wA -= iA * (Vec2.cross(this.m_rA, P) + impulse.z);
+      wA -= iA * (Vec2.crossVec2Vec2(this.m_rA, P) + impulse.z);
 
       vB.addMul(mB, P);
-      wB += iB * (Vec2.cross(this.m_rB, P) + impulse.z);
+      wB += iB * (Vec2.crossVec2Vec2(this.m_rB, P) + impulse.z);
 
     } else {
       // Solve point-to-point constraint
       const Cdot = Vec2.zero();
-      Cdot.addCombine(1, vB, 1, Vec2.cross(wB, this.m_rB));
-      Cdot.subCombine(1, vA, 1, Vec2.cross(wA, this.m_rA));
+      Cdot.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
+      Cdot.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA));
       const impulse = this.m_mass.solve22(Vec2.neg(Cdot)); // Vec2
 
       this.m_impulse.x += impulse.x;
       this.m_impulse.y += impulse.y;
 
       vA.subMul(mA, impulse);
-      wA -= iA * Vec2.cross(this.m_rA, impulse);
+      wA -= iA * Vec2.crossVec2Vec2(this.m_rA, impulse);
 
       vB.addMul(mB, impulse);
-      wB += iB * Vec2.cross(this.m_rB, impulse);
+      wB += iB * Vec2.crossVec2Vec2(this.m_rB, impulse);
     }
 
     this.m_bodyA.c_velocity.v = vA;
@@ -718,15 +718,15 @@ export default class RevoluteJoint extends Joint {
       const impulse = Vec2.neg(K.solve(C)); // Vec2
 
       cA.subMul(mA, impulse);
-      aA -= iA * Vec2.cross(rA, impulse);
+      aA -= iA * Vec2.crossVec2Vec2(rA, impulse);
 
       cB.addMul(mB, impulse);
-      aB += iB * Vec2.cross(rB, impulse);
+      aB += iB * Vec2.crossVec2Vec2(rB, impulse);
     }
 
-    this.m_bodyA.c_position.c.set(cA);
+    this.m_bodyA.c_position.c.setVec2(cA);
     this.m_bodyA.c_position.a = aA;
-    this.m_bodyB.c_position.c.set(cB);
+    this.m_bodyB.c_position.c.setVec2(cB);
     this.m_bodyB.c_position.a = aB;
 
     return positionError <= Settings.linearSlop

--- a/src/dynamics/joint/RevoluteJoint.ts
+++ b/src/dynamics/joint/RevoluteJoint.ts
@@ -694,8 +694,8 @@ export default class RevoluteJoint extends Joint {
 
     // Solve point-to-point constraint.
     {
-      qA.set(aA);
-      qB.set(aB);
+      qA.setAngle(aA);
+      qB.setAngle(aB);
       const rA = Rot.mulVec2(qA, Vec2.sub(this.m_localAnchorA, this.m_localCenterA)); // Vec2
       const rB = Rot.mulVec2(qB, Vec2.sub(this.m_localAnchorB, this.m_localCenterB)); // Vec2
 

--- a/src/dynamics/joint/RevoluteJoint.ts
+++ b/src/dynamics/joint/RevoluteJoint.ts
@@ -563,8 +563,8 @@ export default class RevoluteJoint extends Joint {
     if (this.m_enableLimit && this.m_limitState != inactiveLimit
         && fixedRotation == false) {
       const Cdot1 = Vec2.zero();
-      Cdot1.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
-      Cdot1.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA));
+      Cdot1.addCombine(1, vB, 1, Vec2.crossNumVec2(wB, this.m_rB));
+      Cdot1.subCombine(1, vA, 1, Vec2.crossNumVec2(wA, this.m_rA));
       const Cdot2 = wB - wA; // float
       const Cdot = new Vec3(Cdot1.x, Cdot1.y, Cdot2);
 
@@ -619,8 +619,8 @@ export default class RevoluteJoint extends Joint {
     } else {
       // Solve point-to-point constraint
       const Cdot = Vec2.zero();
-      Cdot.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
-      Cdot.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA));
+      Cdot.addCombine(1, vB, 1, Vec2.crossNumVec2(wB, this.m_rB));
+      Cdot.subCombine(1, vA, 1, Vec2.crossNumVec2(wA, this.m_rA));
       const impulse = this.m_mass.solve22(Vec2.neg(Cdot)); // Vec2
 
       this.m_impulse.x += impulse.x;

--- a/src/dynamics/joint/RopeJoint.ts
+++ b/src/dynamics/joint/RopeJoint.ts
@@ -211,7 +211,7 @@ export default class RopeJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mul(this.m_impulse, this.m_u).mul(inv_dt);
+    return Vec2.mulNumberVec2(this.m_impulse, this.m_u).mul(inv_dt);
   }
 
   /**
@@ -267,8 +267,8 @@ export default class RopeJoint extends Joint {
     }
 
     // Compute effective mass.
-    const crA = Vec2.cross(this.m_rA, this.m_u); // float
-    const crB = Vec2.cross(this.m_rB, this.m_u); // float
+    const crA = Vec2.crossVec2Vec2(this.m_rA, this.m_u); // float
+    const crB = Vec2.crossVec2Vec2(this.m_rB, this.m_u); // float
     const invMass = this.m_invMassA + this.m_invIA * crA * crA + this.m_invMassB
         + this.m_invIB * crB * crB; // float
 
@@ -278,21 +278,21 @@ export default class RopeJoint extends Joint {
       // Scale the impulse to support a variable time step.
       this.m_impulse *= step.dtRatio;
 
-      const P = Vec2.mul(this.m_impulse, this.m_u);
+      const P = Vec2.mulNumberVec2(this.m_impulse, this.m_u);
 
       vA.subMul(this.m_invMassA, P);
-      wA -= this.m_invIA * Vec2.cross(this.m_rA, P);
+      wA -= this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, P);
 
       vB.addMul(this.m_invMassB, P);
-      wB += this.m_invIB * Vec2.cross(this.m_rB, P);
+      wB += this.m_invIB * Vec2.crossVec2Vec2(this.m_rB, P);
 
     } else {
       this.m_impulse = 0.0;
     }
 
-    this.m_bodyA.c_velocity.v.set(vA);
+    this.m_bodyA.c_velocity.v.setVec2(vA);
     this.m_bodyA.c_velocity.w = wA;
-    this.m_bodyB.c_velocity.v.set(vB);
+    this.m_bodyB.c_velocity.v.setVec2(vB);
     this.m_bodyB.c_velocity.w = wB;
   }
 
@@ -303,8 +303,8 @@ export default class RopeJoint extends Joint {
     let wB = this.m_bodyB.c_velocity.w;
 
     // Cdot = dot(u, v + cross(w, r))
-    const vpA = Vec2.addCross(vA, wA, this.m_rA); // Vec2
-    const vpB = Vec2.addCross(vB, wB, this.m_rB); // Vec2
+    const vpA = Vec2.addCrossNumberVec2(vA, wA, this.m_rA); // Vec2
+    const vpB = Vec2.addCrossNumberVec2(vB, wB, this.m_rB); // Vec2
     const C = this.m_length - this.m_maxLength; // float
     let Cdot = Vec2.dot(this.m_u, Vec2.sub(vpB, vpA)); // float
 
@@ -318,11 +318,11 @@ export default class RopeJoint extends Joint {
     this.m_impulse = Math.min(0.0, this.m_impulse + impulse);
     impulse = this.m_impulse - oldImpulse;
 
-    const P = Vec2.mul(impulse, this.m_u); // Vec2
+    const P = Vec2.mulNumberVec2(impulse, this.m_u); // Vec2
     vA.subMul(this.m_invMassA, P);
-    wA -= this.m_invIA * Vec2.cross(this.m_rA, P);
+    wA -= this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, P);
     vB.addMul(this.m_invMassB, P);
-    wB += this.m_invIB * Vec2.cross(this.m_rB, P);
+    wB += this.m_invIB * Vec2.crossVec2Vec2(this.m_rB, P);
 
     this.m_bodyA.c_velocity.v = vA;
     this.m_bodyA.c_velocity.w = wA;
@@ -354,16 +354,16 @@ export default class RopeJoint extends Joint {
     C = Math.clamp(C, 0.0, Settings.maxLinearCorrection);
 
     const impulse = -this.m_mass * C; // float
-    const P = Vec2.mul(impulse, u); // Vec2
+    const P = Vec2.mulNumberVec2(impulse, u); // Vec2
 
     cA.subMul(this.m_invMassA, P);
-    aA -= this.m_invIA * Vec2.cross(rA, P);
+    aA -= this.m_invIA * Vec2.crossVec2Vec2(rA, P);
     cB.addMul(this.m_invMassB, P);
-    aB += this.m_invIB * Vec2.cross(rB, P);
+    aB += this.m_invIB * Vec2.crossVec2Vec2(rB, P);
 
-    this.m_bodyA.c_position.c.set(cA);
+    this.m_bodyA.c_position.c.setVec2(cA);
     this.m_bodyA.c_position.a = aA;
-    this.m_bodyB.c_position.c.set(cB);
+    this.m_bodyB.c_position.c.setVec2(cB);
     this.m_bodyB.c_position.a = aB;
 
     return length - this.m_maxLength < Settings.linearSlop;

--- a/src/dynamics/joint/RopeJoint.ts
+++ b/src/dynamics/joint/RopeJoint.ts
@@ -211,7 +211,7 @@ export default class RopeJoint extends Joint {
    * Get the reaction force on bodyB at the joint anchor in Newtons.
    */
   getReactionForce(inv_dt: number): Vec2 {
-    return Vec2.mulNumberVec2(this.m_impulse, this.m_u).mul(inv_dt);
+    return Vec2.mulNumVec2(this.m_impulse, this.m_u).mul(inv_dt);
   }
 
   /**
@@ -278,7 +278,7 @@ export default class RopeJoint extends Joint {
       // Scale the impulse to support a variable time step.
       this.m_impulse *= step.dtRatio;
 
-      const P = Vec2.mulNumberVec2(this.m_impulse, this.m_u);
+      const P = Vec2.mulNumVec2(this.m_impulse, this.m_u);
 
       vA.subMul(this.m_invMassA, P);
       wA -= this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, P);
@@ -303,8 +303,8 @@ export default class RopeJoint extends Joint {
     let wB = this.m_bodyB.c_velocity.w;
 
     // Cdot = dot(u, v + cross(w, r))
-    const vpA = Vec2.addCrossNumberVec2(vA, wA, this.m_rA); // Vec2
-    const vpB = Vec2.addCrossNumberVec2(vB, wB, this.m_rB); // Vec2
+    const vpA = Vec2.addCrossNumVec2(vA, wA, this.m_rA); // Vec2
+    const vpB = Vec2.addCrossNumVec2(vB, wB, this.m_rB); // Vec2
     const C = this.m_length - this.m_maxLength; // float
     let Cdot = Vec2.dot(this.m_u, Vec2.sub(vpB, vpA)); // float
 
@@ -318,7 +318,7 @@ export default class RopeJoint extends Joint {
     this.m_impulse = Math.min(0.0, this.m_impulse + impulse);
     impulse = this.m_impulse - oldImpulse;
 
-    const P = Vec2.mulNumberVec2(impulse, this.m_u); // Vec2
+    const P = Vec2.mulNumVec2(impulse, this.m_u); // Vec2
     vA.subMul(this.m_invMassA, P);
     wA -= this.m_invIA * Vec2.crossVec2Vec2(this.m_rA, P);
     vB.addMul(this.m_invMassB, P);
@@ -354,7 +354,7 @@ export default class RopeJoint extends Joint {
     C = Math.clamp(C, 0.0, Settings.maxLinearCorrection);
 
     const impulse = -this.m_mass * C; // float
-    const P = Vec2.mulNumberVec2(impulse, u); // Vec2
+    const P = Vec2.mulNumVec2(impulse, u); // Vec2
 
     cA.subMul(this.m_invMassA, P);
     aA -= this.m_invIA * Vec2.crossVec2Vec2(rA, P);

--- a/src/dynamics/joint/WeldJoint.ts
+++ b/src/dynamics/joint/WeldJoint.ts
@@ -200,15 +200,15 @@ export default class WeldJoint extends Joint {
     localAnchorB?: Vec2,
   }): void {
     if (def.anchorA) {
-      this.m_localAnchorA.set(this.m_bodyA.getLocalPoint(def.anchorA));
+      this.m_localAnchorA.setVec2(this.m_bodyA.getLocalPoint(def.anchorA));
     } else if (def.localAnchorA) {
-      this.m_localAnchorA.set(def.localAnchorA);
+      this.m_localAnchorA.setVec2(def.localAnchorA);
     }
 
     if (def.anchorB) {
-      this.m_localAnchorB.set(this.m_bodyB.getLocalPoint(def.anchorB));
+      this.m_localAnchorB.setVec2(this.m_bodyB.getLocalPoint(def.anchorB));
     } else if (def.localAnchorB) {
-      this.m_localAnchorB.set(def.localAnchorB);
+      this.m_localAnchorB.setVec2(def.localAnchorB);
     }
   }
 
@@ -380,10 +380,10 @@ export default class WeldJoint extends Joint {
       const P = Vec2.neo(this.m_impulse.x, this.m_impulse.y);
 
       vA.subMul(mA, P);
-      wA -= iA * (Vec2.cross(this.m_rA, P) + this.m_impulse.z);
+      wA -= iA * (Vec2.crossVec2Vec2(this.m_rA, P) + this.m_impulse.z);
 
       vB.addMul(mB, P);
-      wB += iB * (Vec2.cross(this.m_rB, P) + this.m_impulse.z);
+      wB += iB * (Vec2.crossVec2Vec2(this.m_rB, P) + this.m_impulse.z);
 
     } else {
       this.m_impulse.setZero();
@@ -417,8 +417,8 @@ export default class WeldJoint extends Joint {
       wB += iB * impulse2;
 
       const Cdot1 = Vec2.zero();
-      Cdot1.addCombine(1, vB, 1, Vec2.cross(wB, this.m_rB));
-      Cdot1.subCombine(1, vA, 1, Vec2.cross(wA, this.m_rA)); // Vec2
+      Cdot1.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
+      Cdot1.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA)); // Vec2
 
       const impulse1 = Vec2.neg(Mat33.mulVec2(this.m_mass, Cdot1)); // Vec2
       this.m_impulse.x += impulse1.x;
@@ -427,14 +427,14 @@ export default class WeldJoint extends Joint {
       const P = Vec2.clone(impulse1); // Vec2
 
       vA.subMul(mA, P);
-      wA -= iA * Vec2.cross(this.m_rA, P);
+      wA -= iA * Vec2.crossVec2Vec2(this.m_rA, P);
 
       vB.addMul(mB, P);
-      wB += iB * Vec2.cross(this.m_rB, P);
+      wB += iB * Vec2.crossVec2Vec2(this.m_rB, P);
     } else {
       const Cdot1 = Vec2.zero();
-      Cdot1.addCombine(1, vB, 1, Vec2.cross(wB, this.m_rB));
-      Cdot1.subCombine(1, vA, 1, Vec2.cross(wA, this.m_rA)); // Vec2
+      Cdot1.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
+      Cdot1.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA)); // Vec2
       const Cdot2 = wB - wA; // float
       const Cdot = new Vec3(Cdot1.x, Cdot1.y, Cdot2); // Vec3
 
@@ -444,10 +444,10 @@ export default class WeldJoint extends Joint {
       const P = Vec2.neo(impulse.x, impulse.y);
 
       vA.subMul(mA, P);
-      wA -= iA * (Vec2.cross(this.m_rA, P) + impulse.z);
+      wA -= iA * (Vec2.crossVec2Vec2(this.m_rA, P) + impulse.z);
 
       vB.addMul(mB, P);
-      wB += iB * (Vec2.cross(this.m_rB, P) + impulse.z);
+      wB += iB * (Vec2.crossVec2Vec2(this.m_rB, P) + impulse.z);
     }
 
     this.m_bodyA.c_velocity.v = vA;
@@ -501,10 +501,10 @@ export default class WeldJoint extends Joint {
       const P = Vec2.neg(K.solve22(C1)); // Vec2
 
       cA.subMul(mA, P);
-      aA -= iA * Vec2.cross(rA, P);
+      aA -= iA * Vec2.crossVec2Vec2(rA, P);
 
       cB.addMul(mB, P);
-      aB += iB * Vec2.cross(rB, P);
+      aB += iB * Vec2.crossVec2Vec2(rB, P);
     } else {
       const C1 = Vec2.zero();
       C1.addCombine(1, cB, 1, rB);
@@ -528,10 +528,10 @@ export default class WeldJoint extends Joint {
       const P = Vec2.neo(impulse.x, impulse.y);
 
       cA.subMul(mA, P);
-      aA -= iA * (Vec2.cross(rA, P) + impulse.z);
+      aA -= iA * (Vec2.crossVec2Vec2(rA, P) + impulse.z);
 
       cB.addMul(mB, P);
-      aB += iB * (Vec2.cross(rB, P) + impulse.z);
+      aB += iB * (Vec2.crossVec2Vec2(rB, P) + impulse.z);
     }
 
     this.m_bodyA.c_position.c = cA;

--- a/src/dynamics/joint/WeldJoint.ts
+++ b/src/dynamics/joint/WeldJoint.ts
@@ -417,8 +417,8 @@ export default class WeldJoint extends Joint {
       wB += iB * impulse2;
 
       const Cdot1 = Vec2.zero();
-      Cdot1.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
-      Cdot1.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA)); // Vec2
+      Cdot1.addCombine(1, vB, 1, Vec2.crossNumVec2(wB, this.m_rB));
+      Cdot1.subCombine(1, vA, 1, Vec2.crossNumVec2(wA, this.m_rA)); // Vec2
 
       const impulse1 = Vec2.neg(Mat33.mulVec2(this.m_mass, Cdot1)); // Vec2
       this.m_impulse.x += impulse1.x;
@@ -433,8 +433,8 @@ export default class WeldJoint extends Joint {
       wB += iB * Vec2.crossVec2Vec2(this.m_rB, P);
     } else {
       const Cdot1 = Vec2.zero();
-      Cdot1.addCombine(1, vB, 1, Vec2.crossNumberVec2(wB, this.m_rB));
-      Cdot1.subCombine(1, vA, 1, Vec2.crossNumberVec2(wA, this.m_rA)); // Vec2
+      Cdot1.addCombine(1, vB, 1, Vec2.crossNumVec2(wB, this.m_rB));
+      Cdot1.subCombine(1, vA, 1, Vec2.crossNumVec2(wA, this.m_rA)); // Vec2
       const Cdot2 = wB - wA; // float
       const Cdot = new Vec3(Cdot1.x, Cdot1.y, Cdot2); // Vec3
 

--- a/src/dynamics/joint/WheelJoint.ts
+++ b/src/dynamics/joint/WheelJoint.ts
@@ -160,7 +160,7 @@ export default class WheelJoint extends Joint {
     this.m_localAnchorB = Vec2.clone(anchor ? bodyB.getLocalPoint(anchor) : def.localAnchorB || Vec2.zero());
     // @ts-ignore localAxis
     this.m_localXAxisA = Vec2.clone(axis ? bodyA.getLocalVector(axis) : def.localAxisA || def.localAxis || Vec2.neo(1.0, 0.0));
-    this.m_localYAxisA = Vec2.crossNumberVec2(1.0, this.m_localXAxisA);
+    this.m_localYAxisA = Vec2.crossNumVec2(1.0, this.m_localXAxisA);
 
     this.m_mass = 0.0;
     this.m_impulse = 0.0;
@@ -250,7 +250,7 @@ export default class WheelJoint extends Joint {
 
     if (def.localAxisA) {
       this.m_localXAxisA.setVec2(def.localAxisA);
-      this.m_localYAxisA.setVec2(Vec2.crossNumberVec2(1.0, def.localAxisA));
+      this.m_localYAxisA.setVec2(Vec2.crossNumVec2(1.0, def.localAxisA));
     }
   }
 
@@ -552,7 +552,7 @@ export default class WheelJoint extends Joint {
           * (Cdot + this.m_bias + this.m_gamma * this.m_springImpulse); // float
       this.m_springImpulse += impulse;
 
-      const P = Vec2.mulNumberVec2(impulse, this.m_ax); // Vec2
+      const P = Vec2.mulNumVec2(impulse, this.m_ax); // Vec2
       const LA = impulse * this.m_sAx; // float
       const LB = impulse * this.m_sBx; // float
 
@@ -585,7 +585,7 @@ export default class WheelJoint extends Joint {
       const impulse = -this.m_mass * Cdot; // float
       this.m_impulse += impulse;
 
-      const P = Vec2.mulNumberVec2(impulse, this.m_ay); // Vec2
+      const P = Vec2.mulNumVec2(impulse, this.m_ay); // Vec2
       const LA = impulse * this.m_sAy; // float
       const LB = impulse * this.m_sBy; // float
 
@@ -637,7 +637,7 @@ export default class WheelJoint extends Joint {
       impulse = 0.0;
     }
 
-    const P = Vec2.mulNumberVec2(impulse, ay); // Vec2
+    const P = Vec2.mulNumVec2(impulse, ay); // Vec2
     const LA = impulse * sAy; // float
     const LB = impulse * sBy; // float
 

--- a/src/dynamics/joint/WheelJoint.ts
+++ b/src/dynamics/joint/WheelJoint.ts
@@ -160,7 +160,7 @@ export default class WheelJoint extends Joint {
     this.m_localAnchorB = Vec2.clone(anchor ? bodyB.getLocalPoint(anchor) : def.localAnchorB || Vec2.zero());
     // @ts-ignore localAxis
     this.m_localXAxisA = Vec2.clone(axis ? bodyA.getLocalVector(axis) : def.localAxisA || def.localAxis || Vec2.neo(1.0, 0.0));
-    this.m_localYAxisA = Vec2.cross(1.0, this.m_localXAxisA);
+    this.m_localYAxisA = Vec2.crossNumberVec2(1.0, this.m_localXAxisA);
 
     this.m_mass = 0.0;
     this.m_impulse = 0.0;
@@ -237,20 +237,20 @@ export default class WheelJoint extends Joint {
     localAxisA?: Vec2,
   }): void {
     if (def.anchorA) {
-      this.m_localAnchorA.set(this.m_bodyA.getLocalPoint(def.anchorA));
+      this.m_localAnchorA.setVec2(this.m_bodyA.getLocalPoint(def.anchorA));
     } else if (def.localAnchorA) {
-      this.m_localAnchorA.set(def.localAnchorA);
+      this.m_localAnchorA.setVec2(def.localAnchorA);
     }
 
     if (def.anchorB) {
-      this.m_localAnchorB.set(this.m_bodyB.getLocalPoint(def.anchorB));
+      this.m_localAnchorB.setVec2(this.m_bodyB.getLocalPoint(def.anchorB));
     } else if (def.localAnchorB) {
-      this.m_localAnchorB.set(def.localAnchorB);
+      this.m_localAnchorB.setVec2(def.localAnchorB);
     }
 
     if (def.localAxisA) {
-      this.m_localXAxisA.set(def.localAxisA);
-      this.m_localYAxisA.set(Vec2.cross(1.0, def.localAxisA));
+      this.m_localXAxisA.setVec2(def.localAxisA);
+      this.m_localYAxisA.setVec2(Vec2.crossNumberVec2(1.0, def.localAxisA));
     }
   }
 
@@ -439,8 +439,8 @@ export default class WheelJoint extends Joint {
     // Point to line constraint
     {
       this.m_ay = Rot.mulVec2(qA, this.m_localYAxisA);
-      this.m_sAy = Vec2.cross(Vec2.add(d, rA), this.m_ay);
-      this.m_sBy = Vec2.cross(rB, this.m_ay);
+      this.m_sAy = Vec2.crossVec2Vec2(Vec2.add(d, rA), this.m_ay);
+      this.m_sBy = Vec2.crossVec2Vec2(rB, this.m_ay);
 
       this.m_mass = mA + mB + iA * this.m_sAy * this.m_sAy + iB * this.m_sBy
           * this.m_sBy;
@@ -456,8 +456,8 @@ export default class WheelJoint extends Joint {
     this.m_gamma = 0.0;
     if (this.m_frequencyHz > 0.0) {
       this.m_ax = Rot.mulVec2(qA, this.m_localXAxisA);
-      this.m_sAx = Vec2.cross(Vec2.add(d, rA), this.m_ax);
-      this.m_sBx = Vec2.cross(rB, this.m_ax);
+      this.m_sAx = Vec2.crossVec2Vec2(Vec2.add(d, rA), this.m_ax);
+      this.m_sBx = Vec2.crossVec2Vec2(rB, this.m_ax);
 
       const invMass = mA + mB + iA * this.m_sAx * this.m_sAx + iB * this.m_sBx
           * this.m_sBx; // float
@@ -527,9 +527,9 @@ export default class WheelJoint extends Joint {
       this.m_motorImpulse = 0.0;
     }
 
-    this.m_bodyA.c_velocity.v.set(vA);
+    this.m_bodyA.c_velocity.v.setVec2(vA);
     this.m_bodyA.c_velocity.w = wA;
-    this.m_bodyB.c_velocity.v.set(vB);
+    this.m_bodyB.c_velocity.v.setVec2(vB);
     this.m_bodyB.c_velocity.w = wB;
   }
 
@@ -552,7 +552,7 @@ export default class WheelJoint extends Joint {
           * (Cdot + this.m_bias + this.m_gamma * this.m_springImpulse); // float
       this.m_springImpulse += impulse;
 
-      const P = Vec2.mul(impulse, this.m_ax); // Vec2
+      const P = Vec2.mulNumberVec2(impulse, this.m_ax); // Vec2
       const LA = impulse * this.m_sAx; // float
       const LB = impulse * this.m_sBx; // float
 
@@ -585,7 +585,7 @@ export default class WheelJoint extends Joint {
       const impulse = -this.m_mass * Cdot; // float
       this.m_impulse += impulse;
 
-      const P = Vec2.mul(impulse, this.m_ay); // Vec2
+      const P = Vec2.mulNumberVec2(impulse, this.m_ay); // Vec2
       const LA = impulse * this.m_sAy; // float
       const LB = impulse * this.m_sBy; // float
 
@@ -596,9 +596,9 @@ export default class WheelJoint extends Joint {
       wB += iB * LB;
     }
 
-    this.m_bodyA.c_velocity.v.set(vA);
+    this.m_bodyA.c_velocity.v.setVec2(vA);
     this.m_bodyA.c_velocity.w = wA;
-    this.m_bodyB.c_velocity.v.set(vB);
+    this.m_bodyB.c_velocity.v.setVec2(vB);
     this.m_bodyB.c_velocity.w = wB;
   }
 
@@ -622,8 +622,8 @@ export default class WheelJoint extends Joint {
 
     const ay = Rot.mulVec2(qA, this.m_localYAxisA);
 
-    const sAy = Vec2.cross(Vec2.add(d, rA), ay); // float
-    const sBy = Vec2.cross(rB, ay); // float
+    const sAy = Vec2.crossVec2Vec2(Vec2.add(d, rA), ay); // float
+    const sBy = Vec2.crossVec2Vec2(rB, ay); // float
 
     const C = Vec2.dot(d, ay); // float
 
@@ -637,7 +637,7 @@ export default class WheelJoint extends Joint {
       impulse = 0.0;
     }
 
-    const P = Vec2.mul(impulse, ay); // Vec2
+    const P = Vec2.mulNumberVec2(impulse, ay); // Vec2
     const LA = impulse * sAy; // float
     const LB = impulse * sBy; // float
 
@@ -646,9 +646,9 @@ export default class WheelJoint extends Joint {
     cB.addMul(this.m_invMassB, P);
     aB += this.m_invIB * LB;
 
-    this.m_bodyA.c_position.c.set(cA);
+    this.m_bodyA.c_position.c.setVec2(cA);
     this.m_bodyA.c_position.a = aA;
-    this.m_bodyB.c_position.c.set(cB);
+    this.m_bodyB.c_position.c.setVec2(cB);
     this.m_bodyB.c_position.a = aB;
 
     return Math.abs(C) <= Settings.linearSlop;

--- a/testbed/index.ts
+++ b/testbed/index.ts
@@ -392,7 +392,7 @@ export function testbed(opts, callback?) {
         targetBody = body;
 
       } else {
-        mouseJoint = new MouseJoint({maxForce: 1000}, mouseGround, body, new Vec2(point));
+        mouseJoint = new MouseJoint({maxForce: 1000}, mouseGround, body, Vec2.clone(point));
         world.createJoint(mouseJoint);
       }
 


### PR DESCRIPTION
This results in only pretty minor performance improvements, but its the easiest optimization to apply. I found out that there is more preformance gain when switching to ES6, but that is something for a later date.

Not sure about the names like `addCrossVec2Number`, maybe `addCrossVec2Num`, `addCrossVec2Float` or `addCrossVec2Scalar` would be a better fit?

Also, this is a breaking change, because `vec2.set` and `transform.set` changed. Should we keep them backwards compatible or is there a place to document this otherwise?